### PR TITLE
Adjust to use javascript_tag and take html_options

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,51 @@ And then execute:
     <%= content_for :render_async %>
     ```
 
+## Advanced usage
+
+`render_async` takes two arguments, `path` and `html_options`.
+
+* `path` is the ajax-capable controller action you're looking to call via `get`. e.g. `comments_stats_path`, `posts_path`, etc.
+* `html_options` is an optional hash that gets passed to a rails `javascript_tag`, to drop html tags into the `script` element.
+
+Example utilizing `html_options` with a `nonce`:
+
+    ```ruby
+    <%= render_async users_path, nonce: 'lWaaV6eYicpt+oyOfcShYINsz0b70iR+Q1mohZqNaag=' %>
+    ```
+
+Rendered code in the view:
+
+    ```html
+    <div id="render_async_18b8a6cd161499117471">
+      <div id="render_async_18b8a6cd161499117471_spinner" class="sk-spinner sk-spinner-double-bounce">
+        <div class="sk-double-bounce1"></div>
+        <div class="sk-double-bounce2"></div>
+      </div>
+    </div>
+
+    <script nonce="lWaaV6eYicpt+oyOfcShYINsz0b70iR+Q1mohZqNaag=">
+    //<![CDATA[
+
+        (function($){
+          $.ajax({
+              url: "/users",
+            })
+            .done(function(response, status) {
+              $("#render_async_18b8a6cd161499117471").html(response);
+            })
+            .fail(function(response, status) {
+              $("#render_async_18b8a6cd161499117471").html(response);
+            })
+            .always(function(response, status) {
+              $("#render_async_18b8a6cd161499117471_spinner").hide();
+            });
+        }(jQuery));
+
+    //]]>
+    </script>
+    ```
+
 ## Development
 
 After checking out the repo, run `bin/setup` to install dependencies. Then, run

--- a/README.md
+++ b/README.md
@@ -83,42 +83,40 @@ And then execute:
 * `html_options` is an optional hash that gets passed to a rails `javascript_tag`, to drop html tags into the `script` element.
 
 Example utilizing `html_options` with a `nonce`:
-
-    ```ruby
-    <%= render_async users_path, nonce: 'lWaaV6eYicpt+oyOfcShYINsz0b70iR+Q1mohZqNaag=' %>
-    ```
+```erb
+<%= render_async users_path, nonce: 'lWaaV6eYicpt+oyOfcShYINsz0b70iR+Q1mohZqNaag=' %>
+```
 
 Rendered code in the view:
+```html
+<div id="render_async_18b8a6cd161499117471">
+  <div id="render_async_18b8a6cd161499117471_spinner" class="sk-spinner sk-spinner-double-bounce">
+    <div class="sk-double-bounce1"></div>
+    <div class="sk-double-bounce2"></div>
+  </div>
+</div>
 
-    ```html
-    <div id="render_async_18b8a6cd161499117471">
-      <div id="render_async_18b8a6cd161499117471_spinner" class="sk-spinner sk-spinner-double-bounce">
-        <div class="sk-double-bounce1"></div>
-        <div class="sk-double-bounce2"></div>
-      </div>
-    </div>
+<script nonce="lWaaV6eYicpt+oyOfcShYINsz0b70iR+Q1mohZqNaag=">
+//<![CDATA[
 
-    <script nonce="lWaaV6eYicpt+oyOfcShYINsz0b70iR+Q1mohZqNaag=">
-    //<![CDATA[
+    (function($){
+      $.ajax({
+          url: "/users",
+        })
+        .done(function(response, status) {
+          $("#render_async_18b8a6cd161499117471").html(response);
+        })
+        .fail(function(response, status) {
+          $("#render_async_18b8a6cd161499117471").html(response);
+        })
+        .always(function(response, status) {
+          $("#render_async_18b8a6cd161499117471_spinner").hide();
+        });
+    }(jQuery));
 
-        (function($){
-          $.ajax({
-              url: "/users",
-            })
-            .done(function(response, status) {
-              $("#render_async_18b8a6cd161499117471").html(response);
-            })
-            .fail(function(response, status) {
-              $("#render_async_18b8a6cd161499117471").html(response);
-            })
-            .always(function(response, status) {
-              $("#render_async_18b8a6cd161499117471_spinner").hide();
-            });
-        }(jQuery));
-
-    //]]>
-    </script>
-    ```
+//]]>
+</script>
+```
 
 ## Development
 

--- a/app/views/render_async/_render_async.html.erb
+++ b/app/views/render_async/_render_async.html.erb
@@ -6,7 +6,7 @@
 </div>
 
 <% content_for :render_async do %>
-  <script type="text/javascript">
+  <%= javascript_tag html_options do %>
     (function($){
       $.ajax({
           url: "<%= path %>",
@@ -21,5 +21,5 @@
           $("#<%= container_name %>_spinner").hide();
         });
     }(jQuery));
-  </script>
+  <% end %>
 <% end %>

--- a/lib/render_async/version.rb
+++ b/lib/render_async/version.rb
@@ -1,3 +1,3 @@
 module RenderAsync
-  VERSION = "0.1.3"
+  VERSION = "0.2.3"
 end

--- a/lib/render_async/view_helper.rb
+++ b/lib/render_async/view_helper.rb
@@ -3,11 +3,12 @@ require 'securerandom'
 module RenderAsync
   module ViewHelper
 
-    def render_async(path)
+    def render_async(path, html_options = {})
       container_name = "render_async_#{SecureRandom.hex(5)}#{Time.now.to_i}"
 
       render "render_async/render_async", :container_name => container_name,
-                                          :path => path
+                                          :path => path,
+                                          :html_options => html_options
     end
 
   end


### PR DESCRIPTION
Hey @nikolalsvk , took a stab at this, interested in your thoughts. After some prodding, the most generally useful way to handle this seemed like adjusting the template to use the `javascript_tag` helper in rails. (I'm guessing that's okay because of your use of `content_for`, but please correct me if I'm wrong!) In a nutshell, this subs out the `<script>` for `javascript_tag html_options`, which lets us pop a hash of html options in, and which fixes my particular problem while also having some utility for anyone else who needs to mash in some html options.

See this commit for an example in action: https://github.com/DCAFEngineering/dcaf_case_management/commit/d0e3631c1281aa7df7552c87c27742d34a1b8a2a We add the html option `nonce: content_security_policy_script_nonce`, and it spits out the following into the view itself from the function `<%= render_async patients_report_path(timeframe: 'weekly'), nonce: content_security_policy_script_nonce %>` --

```
<script nonce="lWmnV6eYicpt+oyOfcShYINsz0b70iR+Q1mohZqNsdg=">
//<![CDATA[

    (function($){
      $.ajax({
          url: "/reports/weekly",
        })
        .done(function(response, status) {
          $("#render_async_18b8a6cd161499117471").html(response);
        })
        .fail(function(response, status) {
          $("#render_async_18b8a6cd161499117471").html(response);
        })
        .always(function(response, status) {
          $("#render_async_18b8a6cd161499117471_spinner").hide();
        });
    }(jQuery));

//]]>
</script>
```

I'm admittedly an rspec infant, but if this looks good to you I can take a whack at adding a test as well, let me know.

Please let me know if I can clarify anything, whether I should bump a changelog somewhere, or any other housekeeping stuff. Thanks much!

Fixes #8 

cc @tingaloo