### PR TITLE
Add support for block-supplied loading template

### DIFF
--- a/app/views/render_async/_render_async.html.erb
+++ b/app/views/render_async/_render_async.html.erb
@@ -1,25 +1,13 @@
-<div id="<%= container_name %>">
-  <div id="<%= container_name %>_spinner" class="sk-spinner sk-spinner-double-bounce">
-    <div class="sk-double-bounce1"></div>
-    <div class="sk-double-bounce2"></div>
-  </div>
+<div id="<%= container_id %>">
+  <%= block %>
 </div>
 
 <% content_for :render_async do %>
   <%= javascript_tag html_options do %>
     (function($){
-      $.ajax({
-          url: "<%= path %>",
-        })
-        .done(function(response, status) {
-          $("#<%= container_name %>").html(response);
-        })
-        .fail(function(response, status) {
-          $("#<%= container_name %>").html(response);
-        })
-        .always(function(response, status) {
-          $("#<%= container_name %>_spinner").hide();
-        });
+      $.ajax({ url: "<%= path %>" }).always(function(response) {
+        $("#<%= container_id %>").replaceWith(response);
+      });
     }(jQuery));
   <% end %>
 <% end %>

--- a/lib/render_async/view_helper.rb
+++ b/lib/render_async/view_helper.rb
@@ -3,12 +3,13 @@ require 'securerandom'
 module RenderAsync
   module ViewHelper
 
-    def render_async(path, html_options = {})
-      container_name = "render_async_#{SecureRandom.hex(5)}#{Time.now.to_i}"
+    def render_async(path, html_options = {}, &block)
+      container_id = "render_async_#{SecureRandom.hex(5)}#{Time.now.to_i}"
 
-      render "render_async/render_async", :container_name => container_name,
-                                          :path => path,
-                                          :html_options => html_options
+      render 'render_async/render_async', container_id: container_id,
+                                          path: path,
+                                          html_options: html_options,
+                                          block: capture(&block)
     end
 
   end


### PR DESCRIPTION
This is very useful when you want to provide a loading indicator that is relevant to what is being async loaded. I don't believe this to be the optimal solution, as you lose the ability to have a common (or default) loading template for use-cases where the same one is desired (at least mostly) app-wide.

Usable like:
```erb
<%= render_async some_path do %>
  <div class="loading">
    Loading...
  </div>
<% end %>
```

Also:
 - Removes hard-coded "sk-*" classes loading template
 - Uses `replaceWith` instead of `html` so the loading container isn't left behind after async loading
 - Removes code duplication in AJAX code
 - Renames `container_name` to `container_id` to better reflect usage
 - Switches to Ruby 1.9+ modern hash syntax