### PR TITLE
Add view caching support

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,31 @@ Rendered code in the view:
 </script>
 ```
 
+## Caching
+
+`render_async` can utilize view fragment caching to avoid extra ajax calls on repeat page views.
+
+In your views:
+  ```erb
+  # app/views/comments/show.html.erb
+
+  # note 'render_async_cache' instead of standard 'render_async'
+  <%= render_async_cache comment_stats_path %>
+  ```
+
+  ```erb
+  # app/views/comments/_comment_stats.html.erb
+
+  <% cache render_async_cache_key(path) do %>
+    <div class="col-md-6">
+      <%= @stats %>
+    </div>
+  <% end %>
+  ```
+
+* The first time the page renders, it will make the ajax call.
+* Any other times (until the cache expires), it will render from cache instantly, without needing the page to load and make the ajax call.
+
 ## Development
 
 After checking out the repo, run `bin/setup` to install dependencies. Then, run

--- a/lib/render_async/version.rb
+++ b/lib/render_async/version.rb
@@ -1,3 +1,3 @@
 module RenderAsync
-  VERSION = "0.2.3"
+  VERSION = "0.3.3"
 end

--- a/lib/render_async/view_helper.rb
+++ b/lib/render_async/view_helper.rb
@@ -3,6 +3,16 @@ require 'securerandom'
 module RenderAsync
   module ViewHelper
 
+    def render_async_cache_key(path)
+      "render_async_#{path}"
+    end
+
+    def render_async_cache(path, html_options = {})
+      cached_view = Rails.cache.read("views/#{render_async_cache_key(path)}")
+      render cached_view and return if cached_view.present?
+      render_async(path, html_options)
+    end
+
     def render_async(path, html_options = {})
       container_name = "render_async_#{SecureRandom.hex(5)}#{Time.now.to_i}"
 


### PR DESCRIPTION
Slightly revised version of my previous pull request. Allows user to distinguish between a cache-able partial by using "render_async_cache" and regular render_async partial by using "render_async".