### PR TITLE
Add turbolinks recipe

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,18 @@ In your views:
 * You can expire cache simply by passing `:expires_in` in your view where
   you cache the partial
 
+## Using with Turbolinks
+
+On Turbolinks applications, you may experience caching issues when navigating
+away from, and then back to, a page with a `render_async` call on it. This will
+likely show up as an empty div.
+
+To resolve, tell turbolinks to reload your `render_async` call as follows:
+
+```erb
+  <%= render_async events_path, 'data-turbolinks-track': 'reload' %>
+```
+
 ## Development
 
 After checking out the repo, run `bin/setup` to install dependencies. Then, run


### PR DESCRIPTION
Adds a recipe for using with turbolinks, to solve a problem we were having at DCAF where divs would mysteriously not reload for no good reason, and that no good reason turned out to be turbolinks.

cc @nikolalsvk -- let me know if you'd like any changes made to this, happy to accommodate. 

Fixes https://github.com/renderedtext/render_async/issues/26