### PR TITLE
Don't html-escape the path when outputting JS

### DIFF
--- a/app/views/render_async/_render_async.html.erb
+++ b/app/views/render_async/_render_async.html.erb
@@ -6,7 +6,7 @@
   <%= javascript_tag html_options do %>
     if (jQuery) {
       (function($){
-        $.ajax({ url: "<%= path %>" }).always(function(response) {
+        $.ajax({ url: "<%= path.html_safe %>" }).always(function(response) {
           $("#<%= container_id %>").replaceWith(response);
 
           <% if event_name.present? %>
@@ -21,7 +21,7 @@
         var SUCCESS = 200;
         var ERROR = 400;
 
-        request.open("GET", "<%= path %>", asyncRequest);
+        request.open("GET", "<%= path.html_safe %>", asyncRequest);
 
         request.onload = function() {
           if (request.status >= SUCCESS && request.status < ERROR) {


### PR DESCRIPTION
Shouldn't HTML-escape the path. My particular issue was that I have query params in my path, and the "&" character was getting HTML-escaped, causing issues.