### PR TITLE
Fix async without jQuery

### DIFF
--- a/app/views/render_async/_render_async.html.erb
+++ b/app/views/render_async/_render_async.html.erb
@@ -4,7 +4,7 @@
 
 <% content_for :render_async do %>
   <%= javascript_tag html_options do %>
-    if (jQuery) {
+    if (window.jQuery) {
       (function($){
         $.ajax({ url: "<%= path.html_safe %>" }).always(function(response) {
           $("#<%= container_id %>").replaceWith(response);

--- a/app/views/render_async/_render_async.html.erb
+++ b/app/views/render_async/_render_async.html.erb
@@ -26,6 +26,7 @@
         request.onload = function() {
           if (request.status >= SUCCESS && request.status < ERROR) {
             var container = document.getElementById("<%= container_id %>");
+            container.parentNode.innerHTML = request.response;
 
             <% if event_name.present? %>
               document.dispatchEvent(new Event("<%= event_name %>"));


### PR DESCRIPTION
Commit 1: **Fix jQuery check**

Trying to evaluate `jQuery` when it is `undefined` would throw a `ReferenceError` to the console. Trying to retrieve it on the global `window` instead will result in it being `undefined` if not defined.

An alternative would be to compare the value of `typeof jQuery` to `'undefined'`, if we are concerned that `window` might not be the global scope.

---

Commit 2: **Fix to make jQuery-less async actually render the response**

Prior to this commit, an async request would go out but the response would be ignored, regardless of result.

The issue is that we don't have jQuery's `replaceWith` to replace a DOM node with arbitrary HTML content. The options I found which get us closest are:

 - Use JavaScript's experimental `ChildNode.replaceWith`. This works and replaces the element in-place, but unfortunately does not handle HTML and always adds the content as a TextNode unless passed an element.

 - Set the `innerHTML` of the container to the response's HTML. This works much better, but results in the container div sticking around, potentially causing conflicts with styling/layout. More importantly, it's a divergence from how the jQuery version works (which replaces the container div entirely).

 - The approach taken in this commit, which is to replace the container's parent node's `innerHTML` with the response. This accomplishes both parsing the response as HTML and replacing the container div, but does have a failure case of the parent node containing content other than just the container div, which would be removed by this replacement.

Suggestions for addressing this are welcome.