### PR TITLE
Pass in html_element_name

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ And then execute:
 Advanced usage includes information on different options, such as:
 
   - [Passing in HTML options](#passing-in-html-options)
+  - [Passing in an HTML element name](#passing-in-an-html-element-name)
   - [Passing in a placeholder](#passing-in-a-placeholder)
   - [Passing in an event name](#passing-in-an-event-name)
   - [Caching](#caching)
@@ -105,6 +106,26 @@ Rendered code in the view:
   ...
 //]]>
 </script>
+```
+
+### Passing in an HTML element name
+
+`render_async` can take in an HTML element name, allowing you to control
+what type of container gets rendered. This can be useful when you're using
+[`render_async` inside a table](https://github.com/renderedtext/render_async/issues/12)
+and you need it to render a `tr` element before your request gets loaded, so
+your content doesn't get pushed out of the table.
+
+Example of using HTML element name:
+```erb
+<%= render_async users_path, html_element_name: 'tr' %>
+```
+
+Rendered code in the view:
+```html
+<tr id="render_async_04229e7abe1507987376">
+</tr>
+...
 ```
 
 ### Passing in a placeholder

--- a/app/views/render_async/_render_async.html.erb
+++ b/app/views/render_async/_render_async.html.erb
@@ -1,6 +1,6 @@
-<div id="<%= container_id %>">
+<<%= html_element_name %> id="<%= container_id %>">
   <%= placeholder %>
-</div>
+</<%= html_element_name %>>
 
 <% content_for :render_async do %>
   <%= javascript_tag html_options do %>

--- a/lib/render_async/view_helper.rb
+++ b/lib/render_async/view_helper.rb
@@ -18,11 +18,13 @@ module RenderAsync
     end
 
     def render_async(path, options = {}, &placeholder)
+      html_element_name = options.delete(:html_element_name) || "div"
       container_id = "render_async_#{SecureRandom.hex(5)}#{Time.now.to_i}"
       event_name = options.delete(:event_name)
       placeholder = capture(&placeholder) if block_given?
 
-      render 'render_async/render_async', container_id: container_id,
+      render 'render_async/render_async', html_element_name: html_element_name,
+                                          container_id: container_id,
                                           path: path,
                                           html_options: options,
                                           event_name: event_name,

--- a/spec/render_async/view_helper_spec.rb
+++ b/spec/render_async/view_helper_spec.rb
@@ -42,6 +42,7 @@ describe RenderAsync::ViewHelper do
         expect(helper).to receive(:render).with(
           "render_async/render_async",
           {
+            :html_element_name => "div",
             :container_id => /render_async_/,
             :path => "users",
             :html_options => {},
@@ -65,6 +66,7 @@ describe RenderAsync::ViewHelper do
         expect(helper).to receive(:render).with(
           "render_async/render_async",
           {
+            :html_element_name => "div",
             :container_id => /render_async_/,
             :path => "users",
             :html_options => {},
@@ -77,11 +79,30 @@ describe RenderAsync::ViewHelper do
       end
     end
 
+    context "html_element_name is given inside options hash" do
+      it "renders render_async partial with proper parameters" do
+        expect(helper).to receive(:render).with(
+          "render_async/render_async",
+          {
+            :html_element_name => "tr",
+            :container_id => /render_async_/,
+            :path => "users",
+            :html_options => {},
+            :event_name => nil,
+            :placeholder => nil
+          }
+        )
+
+        helper.render_async("users", :html_element_name => "tr")
+      end
+    end
+
     context "called with html hash inside options hash" do
       it "renders render_async partial with proper parameters" do
         expect(helper).to receive(:render).with(
           "render_async/render_async",
           {
+            :html_element_name => "div",
             :container_id => /render_async_/,
             :path => "users",
             :html_options => { :nonce => "jkg1935safd" },
@@ -99,6 +120,7 @@ describe RenderAsync::ViewHelper do
         expect(helper).to receive(:render).with(
           "render_async/render_async",
           {
+            :html_element_name => "div",
             :container_id => /render_async_/,
             :path => "users",
             :html_options => {},
@@ -122,6 +144,7 @@ describe RenderAsync::ViewHelper do
         expect(helper).to receive(:render).with(
           "render_async/render_async",
           {
+            :html_element_name => "div",
             :container_id => /render_async_/,
             :path => "users",
             :html_options => {},


### PR DESCRIPTION
Passing html_element_name will allow you to control which HTLM element will serve as a container (placeholder) before your request gets loaded. This will prove useful if you're using render_async inside a table.

Should fix https://github.com/renderedtext/render_async/issues/12