### PR TITLE
Configurable AJAX method, headers and body

### DIFF
--- a/app/views/render_async/_render_async.html.erb
+++ b/app/views/render_async/_render_async.html.erb
@@ -8,6 +8,9 @@
                formats: [:js],
                locals:  { container_id: container_id,
                           path: path,
-                          event_name: event_name } %>
+                          method: method,
+                          data: data,
+                          event_name: event_name,
+                          headers: headers } %>
   <% end %>
 <% end %>

--- a/app/views/render_async/_request.js.erb
+++ b/app/views/render_async/_request.js.erb
@@ -7,7 +7,7 @@ if (window.jQuery) {
       $.ajax({
         url: '<%= path.html_safe %>',
         method: '<%= method %>',
-        data: '<%= data.to_s.html_safe %>',
+        data: "<%= escape_javascript(data.to_s.html_safe) %>",
         headers: headers
       }).always(function(response) {
         $("#<%= container_id %>").replaceWith(response);

--- a/app/views/render_async/_request.js.erb
+++ b/app/views/render_async/_request.js.erb
@@ -1,7 +1,15 @@
 if (window.jQuery) {
   (function($) {
     $(document).ready(function() {
-      $.ajax({ url: "<%= path.html_safe %>" }).always(function(response) {
+      var headers = <%= headers.to_json.html_safe %>;
+      headers['X-CSRF-Token'] = document.querySelector('meta[name="csrf-token"]').content;
+
+      $.ajax({
+        url: '<%= path.html_safe %>',
+        method: '<%= method %>',
+        data: '<%= data.to_s.html_safe %>',
+        headers: headers
+      }).always(function(response) {
         $("#<%= container_id %>").replaceWith(response);
 
         <% if event_name.present? %>

--- a/lib/render_async/view_helper.rb
+++ b/lib/render_async/view_helper.rb
@@ -18,17 +18,23 @@ module RenderAsync
     end
 
     def render_async(path, options = {}, &placeholder)
-      html_element_name = options.delete(:html_element_name) || "div"
+      html_element_name = options.delete(:html_element_name) || 'div'
       container_id = "render_async_#{SecureRandom.hex(5)}#{Time.now.to_i}"
       event_name = options.delete(:event_name)
       placeholder = capture(&placeholder) if block_given?
+      method = options.delete(:method) || 'GET'
+      data = options.delete(:data)
+      headers = options.delete(:headers) || {}
 
       render 'render_async/render_async', html_element_name: html_element_name,
                                           container_id: container_id,
                                           path: path,
                                           html_options: options,
                                           event_name: event_name,
-                                          placeholder: placeholder
+                                          placeholder: placeholder,
+                                          method: method,
+                                          data: data,
+                                          headers: headers
     end
 
   end

--- a/spec/render_async/view_helper_spec.rb
+++ b/spec/render_async/view_helper_spec.rb
@@ -47,7 +47,10 @@ describe RenderAsync::ViewHelper do
             :path => "users",
             :html_options => {},
             :event_name => nil,
-            :placeholder => nil
+            :placeholder => nil,
+            :method => 'GET',
+            :data => nil,
+            :headers => {}
           }
         )
 
@@ -71,7 +74,10 @@ describe RenderAsync::ViewHelper do
             :path => "users",
             :html_options => {},
             :event_name => nil,
-            :placeholder => nil
+            :placeholder => nil,
+            :method => 'GET',
+            :data => nil,
+            :headers => {}
           }
         )
 
@@ -89,7 +95,10 @@ describe RenderAsync::ViewHelper do
             :path => "users",
             :html_options => {},
             :event_name => nil,
-            :placeholder => nil
+            :placeholder => nil,
+            :method => 'GET',
+            :data => nil,
+            :headers => {}
           }
         )
 
@@ -107,7 +116,10 @@ describe RenderAsync::ViewHelper do
             :path => "users",
             :html_options => { :nonce => "jkg1935safd" },
             :event_name => nil,
-            :placeholder => nil
+            :placeholder => nil,
+            :method => 'GET',
+            :data => nil,
+            :headers => {}
           }
         )
 
@@ -125,7 +137,10 @@ describe RenderAsync::ViewHelper do
             :path => "users",
             :html_options => {},
             :event_name => "render_async_done",
-            :placeholder => nil
+            :placeholder => nil,
+            :method => 'GET',
+            :data => nil,
+            :headers => {}
           }
         )
 
@@ -149,11 +164,40 @@ describe RenderAsync::ViewHelper do
             :path => "users",
             :html_options => {},
             :event_name => nil,
-            :placeholder => placeholder
+            :placeholder => placeholder,
+            :method => 'GET',
+            :data => nil,
+            :headers => {}
           }
         )
 
         helper.render_async("users") { placeholder }
+      end
+    end
+
+    context "json post request" do
+      it "renders render_async partial with proper parameters" do
+        expect(helper).to receive(:render).with(
+          "render_async/render_async",
+          {
+            :html_element_name => "div",
+            :container_id => /render_async_/,
+            :path => "users",
+            :html_options => {},
+            :event_name => nil,
+            :placeholder => nil,
+            :method => 'POST',
+            :data => { 'foor' => 'bar' }.to_json,
+            :headers => { 'Content-Type' => 'application/json' }
+          }
+        )
+
+        helper.render_async(
+          "users",
+          :method => 'POST',
+          :data => { 'foor' => 'bar' }.to_json,
+          :headers => { 'Content-Type' => 'application/json' }
+        )
       end
     end
   end


### PR DESCRIPTION
This PR allows render_async to use POST (or any other method) for control. For example, it can be useful when a length of parameters is potentially too long.

