### PR TITLE
Add recipe for using with respond_to/format.js

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ Advanced usage includes information on different options, such as:
   - [Passing in an event name](#passing-in-an-event-name)
   - [Caching](#caching)
   - [Using with Turbolinks](#using-with-turbolinks)
+  - [Using with respond_to and JS format](#using-with-respond-to-and-js-format)
   - [Nested Async Renders](#nested-async-renders)
 
 ### Passing in HTML options
@@ -230,6 +231,30 @@ To resolve, tell turbolinks to reload your `render_async` call as follows:
 
 Make sure to put `<%= content_for :render_async %>` in your base view file in
 the `<head>` and not the `<body>`.
+
+### Using with respond_to and JS format
+
+If you need to restrict the action to only respond to AJAX requests, you'll likely wrap it inside `respond_to`/`format.js` blocks:
+
+```ruby
+def comment_stats
+  respond_to do |format|
+    format.js do
+      @stats = Comment.get_stats
+      
+      render :partial => "comment_stats"
+    end
+  end
+end
+```
+
+When you do this, Rails sets the response's `Content-Type` header to `text/javascript`. This causes the partial not to be rendered.
+
+You can get around that by specifying the content type to `text/html` in the render call:
+
+```ruby
+render :partial => "comment_stats", :content_type => 'text/html'
+```
 
 ### Nested Async Renders
 


### PR DESCRIPTION
Closes #53.

Update the README with a recipe for using the gem when `respond_to`/`format.js` blocks are used. By restricting the action to only answering AJAX requests, we restrict users accessing the partial by typing the action's path in the URL.

When `format.js` is used, Rails automatically sets the response's `Content-Type` to `text/javascript`. This causes the `$.ajax` call to incorrectly parse the response, failing to replace the content.

We need to explicitly set the response's `Content-Type` to `text/html` in the render call to fix that.