### PR TITLE
Add option to pass in container_class and container_id

### DIFF
--- a/app/views/render_async/_render_async.html.erb
+++ b/app/views/render_async/_render_async.html.erb
@@ -1,4 +1,7 @@
-<<%= html_element_name %> id="<%= container_id %>">
+<<%= html_element_name %>
+  id="<%= container_id %>"
+  class="<%= container_class %>"
+>
   <%= placeholder %>
 </<%= html_element_name %>>
 

--- a/lib/render_async/view_helper.rb
+++ b/lib/render_async/view_helper.rb
@@ -19,7 +19,8 @@ module RenderAsync
 
     def render_async(path, options = {}, &placeholder)
       html_element_name = options.delete(:html_element_name) || 'div'
-      container_id = "render_async_#{SecureRandom.hex(5)}#{Time.now.to_i}"
+      container_id = options.delete(:container_id) || generate_container_id
+      container_class = options.delete(:container_class)
       event_name = options.delete(:event_name)
       placeholder = capture(&placeholder) if block_given?
       method = options.delete(:method) || 'GET'
@@ -28,6 +29,7 @@ module RenderAsync
 
       render 'render_async/render_async', html_element_name: html_element_name,
                                           container_id: container_id,
+                                          container_class: container_class,
                                           path: path,
                                           html_options: options,
                                           event_name: event_name,
@@ -37,5 +39,10 @@ module RenderAsync
                                           headers: headers
     end
 
+    private
+
+    def generate_container_id
+      "render_async_#{SecureRandom.hex(5)}#{Time.now.to_i}"
+    end
   end
 end

--- a/spec/render_async/view_helper_spec.rb
+++ b/spec/render_async/view_helper_spec.rb
@@ -44,6 +44,7 @@ describe RenderAsync::ViewHelper do
           {
             :html_element_name => "div",
             :container_id => /render_async_/,
+            :container_class => nil,
             :path => "users",
             :html_options => {},
             :event_name => nil,
@@ -71,6 +72,7 @@ describe RenderAsync::ViewHelper do
           {
             :html_element_name => "div",
             :container_id => /render_async_/,
+            :container_class => nil,
             :path => "users",
             :html_options => {},
             :event_name => nil,
@@ -85,6 +87,50 @@ describe RenderAsync::ViewHelper do
       end
     end
 
+    context "container_id is given inside options hash" do
+      it "renders render_async partial with proper parameters" do
+        expect(helper).to receive(:render).with(
+          "render_async/render_async",
+          {
+            :html_element_name => "div",
+            :container_id => "users-container",
+            :container_class => nil,
+            :path => "users",
+            :html_options => {},
+            :event_name => nil,
+            :placeholder => nil,
+            :method => 'GET',
+            :data => nil,
+            :headers => {}
+          }
+        )
+
+        helper.render_async("users", container_id: "users-container")
+      end
+    end
+
+    context "container_class is given inside options hash" do
+      it "renders render_async partial with proper parameters" do
+        expect(helper).to receive(:render).with(
+          "render_async/render_async",
+          {
+            :html_element_name => "div",
+            :container_id => /render_async_/,
+            :container_class => 'users-placeholder',
+            :path => "users",
+            :html_options => {},
+            :event_name => nil,
+            :placeholder => nil,
+            :method => 'GET',
+            :data => nil,
+            :headers => {}
+          }
+        )
+
+        helper.render_async("users", container_class: "users-placeholder")
+      end
+    end
+
     context "html_element_name is given inside options hash" do
       it "renders render_async partial with proper parameters" do
         expect(helper).to receive(:render).with(
@@ -92,6 +138,7 @@ describe RenderAsync::ViewHelper do
           {
             :html_element_name => "tr",
             :container_id => /render_async_/,
+            :container_class => nil,
             :path => "users",
             :html_options => {},
             :event_name => nil,
@@ -113,6 +160,7 @@ describe RenderAsync::ViewHelper do
           {
             :html_element_name => "div",
             :container_id => /render_async_/,
+            :container_class => nil,
             :path => "users",
             :html_options => { :nonce => "jkg1935safd" },
             :event_name => nil,
@@ -134,6 +182,7 @@ describe RenderAsync::ViewHelper do
           {
             :html_element_name => "div",
             :container_id => /render_async_/,
+            :container_class => nil,
             :path => "users",
             :html_options => {},
             :event_name => "render_async_done",
@@ -161,6 +210,7 @@ describe RenderAsync::ViewHelper do
           {
             :html_element_name => "div",
             :container_id => /render_async_/,
+            :container_class => nil,
             :path => "users",
             :html_options => {},
             :event_name => nil,
@@ -182,6 +232,7 @@ describe RenderAsync::ViewHelper do
           {
             :html_element_name => "div",
             :container_id => /render_async_/,
+            :container_class => nil,
             :path => "users",
             :html_options => {},
             :event_name => nil,


### PR DESCRIPTION
You can now customize the element that will get replaced by the content of your request.
There's 2 ways of customizing it:
1. Pass in the container ID with `container_id: 'comments-container'`
2. Pass in the class name of the container element with `container_class: 'comments-placeholder'`

E.g.

```erb
<%= render_async some_path, container_id: 'comments-container' %>
```
or
```erb
<%= render_async some_path, container_class: 'comments-placeholder' %>
```

Closes https://github.com/renderedtext/render_async/issues/57