### PR TITLE
Handle request errors

### DIFF
--- a/app/views/render_async/_render_async.html.erb
+++ b/app/views/render_async/_render_async.html.erb
@@ -14,6 +14,8 @@
                           method: method,
                           data: data,
                           event_name: event_name,
-                          headers: headers } %>
+                          headers: headers,
+                          error_message: error_message,
+                          error_event_name: error_event_name } %>
   <% end %>
 <% end %>

--- a/app/views/render_async/_request.js.erb
+++ b/app/views/render_async/_request.js.erb
@@ -11,7 +11,7 @@ if (window.jQuery) {
         method: '<%= method %>',
         data: "<%= escape_javascript(data.to_s.html_safe) %>",
         headers: headers
-      }).always(function(response) {
+      }).done(function(response) {
         $("#<%= container_id %>").replaceWith(response);
 
         <% if event_name.present? %>
@@ -21,6 +21,19 @@ if (window.jQuery) {
           } else {
             event = document.createEvent('Event');
             event.initEvent('<%= event_name %>', true, true);
+          }
+          document.dispatchEvent(event);
+        <% end %>
+      }).error(function(response) {
+        $("#<%= container_id %>").replaceWith('<%= error_message.try(:html_safe) %>');
+
+        <% if error_event_name.present? %>
+          var event = undefined;
+          if (typeof(Event) === 'function') {
+            event = new Event("<%= error_event_name %>");
+          } else {
+            event = document.createEvent('Event');
+            event.initEvent('<%= error_event_name %>', true, true);
           }
           document.dispatchEvent(event);
         <% end %>
@@ -46,21 +59,37 @@ if (window.jQuery) {
         request.setRequestHeader(key, headers[key]);
       });
 
-      request.onload = function() {
-        if (request.status >= SUCCESS && request.status < ERROR) {
-          var container = document.getElementById('<%= container_id %>');
-          container.outerHTML = request.response;
+      request.onreadystatechange = function() {
+        if (request.readyState === 4) {
+          if (request.status >= SUCCESS && request.status < ERROR) {
+            var container = document.getElementById('<%= container_id %>');
+            container.outerHTML = request.response;
 
-          <% if event_name.present? %>
-            var event = undefined;
-            if (typeof(Event) === 'function') {
-              event = new Event("<%= event_name %>");
-            } else {
-              event = document.createEvent('Event');
-              event.initEvent('<%= event_name %>', true, true);
-            }
-            document.dispatchEvent(event);
-          <% end %>
+            <% if event_name.present? %>
+              var event = undefined;
+              if (typeof(Event) === 'function') {
+                event = new Event("<%= event_name %>");
+              } else {
+                event = document.createEvent('Event');
+                event.initEvent('<%= event_name %>', true, true);
+              }
+              document.dispatchEvent(event);
+            <% end %>
+          } else {
+            var container = document.getElementById('<%= container_id %>');
+            container.outerHTML = '<%= error_message.try(:html_safe) %>';
+
+            <% if error_event_name.present? %>
+              var event = undefined;
+              if (typeof(Event) === 'function') {
+                event = new Event("<%= error_event_name %>");
+              } else {
+                event = document.createEvent('Event');
+                event.initEvent('<%= error_event_name %>', true, true);
+              }
+              document.dispatchEvent(event);
+            <% end %>
+          }
         }
       };
 

--- a/lib/render_async/view_helper.rb
+++ b/lib/render_async/view_helper.rb
@@ -26,6 +26,8 @@ module RenderAsync
       method = options.delete(:method) || 'GET'
       data = options.delete(:data)
       headers = options.delete(:headers) || {}
+      error_message = options.delete(:error_message)
+      error_event_name = options.delete(:error_event_name)
 
       render 'render_async/render_async', html_element_name: html_element_name,
                                           container_id: container_id,
@@ -36,7 +38,9 @@ module RenderAsync
                                           placeholder: placeholder,
                                           method: method,
                                           data: data,
-                                          headers: headers
+                                          headers: headers,
+                                          error_message: error_message,
+                                          error_event_name: error_event_name
     end
 
     private

--- a/spec/render_async/view_helper_spec.rb
+++ b/spec/render_async/view_helper_spec.rb
@@ -11,8 +11,8 @@ describe RenderAsync::ViewHelper do
 
   describe "#render_async_cache" do
     let(:cached_view) { double("CachedView",
-                               :html_safe => "<h1>I'm cache</h1>",
-                               :present? => true) }
+                               html_safe: "<h1>I'm cache</h1>",
+                               present?: true) }
     before do
       stub_const("Rails", double("Rails"))
     end
@@ -24,7 +24,7 @@ describe RenderAsync::ViewHelper do
 
       it "renders cached HTML" do
         expect(helper).to receive(:render).with(
-          :html => "<h1>I'm cache</h1>"
+          html: "<h1>I'm cache</h1>"
         )
 
         helper.render_async_cache("users")
@@ -32,7 +32,7 @@ describe RenderAsync::ViewHelper do
     end
 
     context "cache is not present" do
-      let(:empty_cache) { double("EmtpyCache", :present? => false) }
+      let(:empty_cache) { double("EmptyCache", present?: false) }
 
       before do
         allow(Rails).to receive_message_chain(:cache, :read).and_return(empty_cache)
@@ -42,16 +42,18 @@ describe RenderAsync::ViewHelper do
         expect(helper).to receive(:render).with(
           "render_async/render_async",
           {
-            :html_element_name => "div",
-            :container_id => /render_async_/,
-            :container_class => nil,
-            :path => "users",
-            :html_options => {},
-            :event_name => nil,
-            :placeholder => nil,
-            :method => 'GET',
-            :data => nil,
-            :headers => {}
+            html_element_name: "div",
+            container_id: /render_async_/,
+            container_class: nil,
+            path: "users",
+            html_options: {},
+            event_name: nil,
+            placeholder: nil,
+            method: 'GET',
+            data: nil,
+            headers: {},
+            error_message: nil,
+            error_event_name: nil
           }
         )
 
@@ -70,16 +72,18 @@ describe RenderAsync::ViewHelper do
         expect(helper).to receive(:render).with(
           "render_async/render_async",
           {
-            :html_element_name => "div",
-            :container_id => /render_async_/,
-            :container_class => nil,
-            :path => "users",
-            :html_options => {},
-            :event_name => nil,
-            :placeholder => nil,
-            :method => 'GET',
-            :data => nil,
-            :headers => {}
+            html_element_name: "div",
+            container_id: /render_async_/,
+            container_class: nil,
+            path: "users",
+            html_options: {},
+            event_name: nil,
+            placeholder: nil,
+            method: 'GET',
+            data: nil,
+            headers: {},
+            error_message: nil,
+            error_event_name: nil
           }
         )
 
@@ -92,16 +96,18 @@ describe RenderAsync::ViewHelper do
         expect(helper).to receive(:render).with(
           "render_async/render_async",
           {
-            :html_element_name => "div",
-            :container_id => "users-container",
-            :container_class => nil,
-            :path => "users",
-            :html_options => {},
-            :event_name => nil,
-            :placeholder => nil,
-            :method => 'GET',
-            :data => nil,
-            :headers => {}
+            html_element_name: "div",
+            container_id: "users-container",
+            container_class: nil,
+            path: "users",
+            html_options: {},
+            event_name: nil,
+            placeholder: nil,
+            method: 'GET',
+            data: nil,
+            headers: {},
+            error_message: nil,
+            error_event_name: nil
           }
         )
 
@@ -114,16 +120,18 @@ describe RenderAsync::ViewHelper do
         expect(helper).to receive(:render).with(
           "render_async/render_async",
           {
-            :html_element_name => "div",
-            :container_id => /render_async_/,
-            :container_class => 'users-placeholder',
-            :path => "users",
-            :html_options => {},
-            :event_name => nil,
-            :placeholder => nil,
-            :method => 'GET',
-            :data => nil,
-            :headers => {}
+            html_element_name: "div",
+            container_id: /render_async_/,
+            container_class: 'users-placeholder',
+            path: "users",
+            html_options: {},
+            event_name: nil,
+            placeholder: nil,
+            method: 'GET',
+            data: nil,
+            headers: {},
+            error_message: nil,
+            error_event_name: nil
           }
         )
 
@@ -136,20 +144,22 @@ describe RenderAsync::ViewHelper do
         expect(helper).to receive(:render).with(
           "render_async/render_async",
           {
-            :html_element_name => "tr",
-            :container_id => /render_async_/,
-            :container_class => nil,
-            :path => "users",
-            :html_options => {},
-            :event_name => nil,
-            :placeholder => nil,
-            :method => 'GET',
-            :data => nil,
-            :headers => {}
+            html_element_name: "tr",
+            container_id: /render_async_/,
+            container_class: nil,
+            path: "users",
+            html_options: {},
+            event_name: nil,
+            placeholder: nil,
+            method: 'GET',
+            data: nil,
+            headers: {},
+            error_message: nil,
+            error_event_name: nil
           }
         )
 
-        helper.render_async("users", :html_element_name => "tr")
+        helper.render_async("users", html_element_name: "tr")
       end
     end
 
@@ -158,20 +168,22 @@ describe RenderAsync::ViewHelper do
         expect(helper).to receive(:render).with(
           "render_async/render_async",
           {
-            :html_element_name => "div",
-            :container_id => /render_async_/,
-            :container_class => nil,
-            :path => "users",
-            :html_options => { :nonce => "jkg1935safd" },
-            :event_name => nil,
-            :placeholder => nil,
-            :method => 'GET',
-            :data => nil,
-            :headers => {}
+            html_element_name: "div",
+            container_id: /render_async_/,
+            container_class: nil,
+            path: "users",
+            html_options: { nonce: "jkg1935safd" },
+            event_name: nil,
+            placeholder: nil,
+            method: 'GET',
+            data: nil,
+            headers: {},
+            error_message: nil,
+            error_event_name: nil
           }
         )
 
-        helper.render_async("users", :nonce => "jkg1935safd")
+        helper.render_async("users", nonce: "jkg1935safd")
       end
     end
 
@@ -180,20 +192,22 @@ describe RenderAsync::ViewHelper do
         expect(helper).to receive(:render).with(
           "render_async/render_async",
           {
-            :html_element_name => "div",
-            :container_id => /render_async_/,
-            :container_class => nil,
-            :path => "users",
-            :html_options => {},
-            :event_name => "render_async_done",
-            :placeholder => nil,
-            :method => 'GET',
-            :data => nil,
-            :headers => {}
+            html_element_name: "div",
+            container_id: /render_async_/,
+            container_class: nil,
+            path: "users",
+            html_options: {},
+            event_name: "render_async_done",
+            placeholder: nil,
+            method: 'GET',
+            data: nil,
+            headers: {},
+            error_message: nil,
+            error_event_name: nil
           }
         )
 
-        helper.render_async("users", :event_name => "render_async_done")
+        helper.render_async("users", event_name: "render_async_done")
       end
     end
 
@@ -208,16 +222,18 @@ describe RenderAsync::ViewHelper do
         expect(helper).to receive(:render).with(
           "render_async/render_async",
           {
-            :html_element_name => "div",
-            :container_id => /render_async_/,
-            :container_class => nil,
-            :path => "users",
-            :html_options => {},
-            :event_name => nil,
-            :placeholder => placeholder,
-            :method => 'GET',
-            :data => nil,
-            :headers => {}
+            html_element_name: "div",
+            container_id: /render_async_/,
+            container_class: nil,
+            path: "users",
+            html_options: {},
+            event_name: nil,
+            placeholder: placeholder,
+            method: 'GET',
+            data: nil,
+            headers: {},
+            error_message: nil,
+            error_event_name: nil
           }
         )
 
@@ -230,24 +246,26 @@ describe RenderAsync::ViewHelper do
         expect(helper).to receive(:render).with(
           "render_async/render_async",
           {
-            :html_element_name => "div",
-            :container_id => /render_async_/,
-            :container_class => nil,
-            :path => "users",
-            :html_options => {},
-            :event_name => nil,
-            :placeholder => nil,
-            :method => 'POST',
-            :data => { 'foor' => 'bar' }.to_json,
-            :headers => { 'Content-Type' => 'application/json' }
+            html_element_name: "div",
+            container_id: /render_async_/,
+            container_class: nil,
+            path: "users",
+            html_options: {},
+            event_name: nil,
+            placeholder: nil,
+            method: 'POST',
+            data: { 'foor' => 'bar' }.to_json,
+            headers: { 'Content-Type' => 'application/json' },
+            error_message: nil,
+            error_event_name: nil
           }
         )
 
         helper.render_async(
           "users",
-          :method => 'POST',
-          :data => { 'foor' => 'bar' }.to_json,
-          :headers => { 'Content-Type' => 'application/json' }
+          method: 'POST',
+          data: { 'foor' => 'bar' }.to_json,
+          headers: { 'Content-Type' => 'application/json' }
         )
       end
     end


### PR DESCRIPTION
You can now pass in error message to be shown if the requests fails for some reason.

E.g.
```erb
<%= render_async users_path, 
                 error_message: '<p>I'm sorry, there's been an error :(</p>' %>
```

Additionaly, you can pass in error event name to be dispatched on the request error.

E.g.

```erb
<%= render_async users_path, error_event_name: 'users-load-error' %>
```
And later on, catch it:

```js
document.addEventListener('users-load-error', function() {
  // do something
})
```

Closes https://github.com/renderedtext/render_async/issues/51