### PR TITLE
Adding support for Turbolinks 5+

### DIFF
--- a/README.md
+++ b/README.md
@@ -388,7 +388,8 @@ You can configure it by doing the following anywhere before you call
 `render_async`:
 ```rb
 RenderAsync.configure do |config|
-  jquery = true # This will render jQuery code, and skip Vanilla JS code
+  config.jquery = true # This will render jQuery code, and skip Vanilla JS code
+  config.turbolinks = false # Enable this option if you are using Turbolinks 5+
 end
 ```
 

--- a/app/views/render_async/_render_async.html.erb
+++ b/app/views/render_async/_render_async.html.erb
@@ -17,7 +17,8 @@
                             event_name: event_name,
                             headers: headers,
                             error_message: error_message,
-                            error_event_name: error_event_name } %>
+                            error_event_name: error_event_name,
+                            turbolinks: RenderAsync.configuration.turbolinks } %>
     <% else %>
       <%= render partial: 'render_async/request_vanilla',
                  formats: [:js],
@@ -28,7 +29,8 @@
                             event_name: event_name,
                             headers: headers,
                             error_message: error_message,
-                            error_event_name: error_event_name } %>
+                            error_event_name: error_event_name,
+                            turbolinks: RenderAsync.configuration.turbolinks } %>
     <% end %>
   <% end %>
 <% end %>

--- a/app/views/render_async/_request_jquery.js.erb
+++ b/app/views/render_async/_request_jquery.js.erb
@@ -1,6 +1,12 @@
 if (window.jQuery) {
   (function($) {
-    $(document).ready(function() {
+    <% if turbolinks %>
+    if (document.documentElement.hasAttribute("data-turbolinks-preview")) {
+      return;
+    }
+    <% end %>
+
+    var _listener = function() {
       var headers = <%= headers.to_json.html_safe %>;
       var csrfTokenElement = document.querySelector('meta[name="csrf-token"]')
       if (csrfTokenElement)
@@ -38,7 +44,13 @@ if (window.jQuery) {
           document.dispatchEvent(event);
         <% end %>
       });
-    });
+    };
+
+    <% if turbolinks %>
+    $(document).one('turbolinks:load', _listener);
+    <% else %>
+    $(document).ready(_listener);
+    <% end %>
   }(jQuery));
 } else {
   console.warn("Looks like you've enabled jQuery for render_async, but jQuery is not defined");

--- a/app/views/render_async/_request_jquery.js.erb
+++ b/app/views/render_async/_request_jquery.js.erb
@@ -30,7 +30,7 @@ if (window.jQuery) {
           }
           document.dispatchEvent(event);
         <% end %>
-      }).error(function(response) {
+      }).fail(function(response) {
         $("#<%= container_id %>").replaceWith('<%= error_message.try(:html_safe) %>');
 
         <% if error_event_name.present? %>

--- a/app/views/render_async/_request_vanilla.js.erb
+++ b/app/views/render_async/_request_vanilla.js.erb
@@ -1,5 +1,11 @@
 (function() {
-  document.addEventListener("DOMContentLoaded", function() {
+  <% if turbolinks %>
+  if (document.documentElement.hasAttribute("data-turbolinks-preview")) {
+    return;
+  }
+  <% end %>
+  
+  var _listener = function() {
     var request = new XMLHttpRequest();
     var asyncRequest = true;
     var SUCCESS = 200;
@@ -52,5 +58,14 @@
 
     var body = "<%= escape_javascript(data.to_s.html_safe) %>";
     request.send(body);
+  };
+
+  <% if turbolinks %>
+  document.addEventListener("turbolinks:load", function (e) {
+    e.target.removeEventListener(e.type, arguments.callee);
+    _listener.call(this);
   });
+  <% else %>
+  document.addEventListener("DOMContentLoaded", _listener);
+  <% end %>
 })();

--- a/lib/render_async/configuration.rb
+++ b/lib/render_async/configuration.rb
@@ -1,9 +1,10 @@
 module RenderAsync
   class Configuration
-    attr_accessor :jquery
+    attr_accessor :jquery, :turbolinks
 
     def initialize
       @jquery = false
+      @turbolinks = false
     end
   end
 end


### PR DESCRIPTION
Adding support for Turbolins 5+
- [x] Configuration option to indicate if your project uses Turbolinks 5+ (default: false)
- [x] JavaScript Vanilla
  - [x] Add a condition to avoid render_async be executed on preview pages
  - [x] Add Turbolinks on load event 
- [x] jQuery
  - [x] Add a condition to avoid render_async be executed on preview pages
  - [x] Add Turbolinks on load event