### PR TITLE
Retry render_async on failure

### DIFF
--- a/app/views/render_async/_render_async.html.erb
+++ b/app/views/render_async/_render_async.html.erb
@@ -18,6 +18,7 @@
                             headers: headers,
                             error_message: error_message,
                             error_event_name: error_event_name,
+                            retry_count: retry_count,
                             turbolinks: RenderAsync.configuration.turbolinks } %>
     <% else %>
       <%= render partial: 'render_async/request_vanilla',
@@ -30,6 +31,7 @@
                             headers: headers,
                             error_message: error_message,
                             error_event_name: error_event_name,
+                            retry_count: retry_count,
                             turbolinks: RenderAsync.configuration.turbolinks } %>
     <% end %>
   <% end %>

--- a/app/views/render_async/_request_jquery.js.erb
+++ b/app/views/render_async/_request_jquery.js.erb
@@ -31,7 +31,7 @@ if (window.jQuery) {
           document.dispatchEvent(event);
         <% end %>
       }).fail(function(response) {
-        var skipErrorMessage = true;
+        var skipErrorMessage = false;
         <% if retry_count > 0 %>
         skipErrorMessage = retry(currentRetryCount)
         <% end %>

--- a/app/views/render_async/_request_jquery.js.erb
+++ b/app/views/render_async/_request_jquery.js.erb
@@ -6,7 +6,7 @@ if (window.jQuery) {
     }
     <% end %>
 
-    var _listener = function() {
+    var _listener = function(currentRetryCount) {
       var headers = <%= headers.to_json.html_safe %>;
       var csrfTokenElement = document.querySelector('meta[name="csrf-token"]')
       if (csrfTokenElement)
@@ -31,6 +31,13 @@ if (window.jQuery) {
           document.dispatchEvent(event);
         <% end %>
       }).fail(function(response) {
+        var skipErrorMessage = true;
+        <% if retry_count > 0 %>
+        skipErrorMessage = retry(currentRetryCount)
+        <% end %>
+
+        if (skipErrorMessage) return;
+
         $("#<%= container_id %>").replaceWith('<%= error_message.try(:html_safe) %>');
 
         <% if error_event_name.present? %>
@@ -45,6 +52,21 @@ if (window.jQuery) {
         <% end %>
       });
     };
+
+    <% if retry_count > 0 %>
+    var retry = function(currentRetryCount) {
+      if (typeof(currentRetryCount) === 'number') {
+        if (currentRetryCount >= <%= retry_count %>)
+          return false;
+
+        _listener(currentRetryCount + 1);
+        return true;
+      }
+
+      _listener(1);
+      return true;
+    }
+    <% end %>
 
     <% if turbolinks %>
     $(document).one('turbolinks:load', _listener);

--- a/app/views/render_async/_request_vanilla.js.erb
+++ b/app/views/render_async/_request_vanilla.js.erb
@@ -39,7 +39,7 @@
             document.dispatchEvent(event);
           <% end %>
         } else {
-          var skipErrorMessage = true;
+          var skipErrorMessage = false;
           <% if retry_count > 0 %>
           skipErrorMessage = retry(currentRetryCount)
           <% end %>

--- a/app/views/render_async/_request_vanilla.js.erb
+++ b/app/views/render_async/_request_vanilla.js.erb
@@ -5,7 +5,7 @@
   }
   <% end %>
   
-  var _listener = function() {
+  var _listener = function(currentRetryCount) {
     var request = new XMLHttpRequest();
     var asyncRequest = true;
     var SUCCESS = 200;
@@ -39,6 +39,13 @@
             document.dispatchEvent(event);
           <% end %>
         } else {
+          var skipErrorMessage = true;
+          <% if retry_count > 0 %>
+          skipErrorMessage = retry(currentRetryCount)
+          <% end %>
+
+          if (skipErrorMessage) return;
+
           var container = document.getElementById('<%= container_id %>');
           container.outerHTML = '<%= error_message.try(:html_safe) %>';
 
@@ -59,6 +66,21 @@
     var body = "<%= escape_javascript(data.to_s.html_safe) %>";
     request.send(body);
   };
+
+  <% if retry_count > 0 %>
+  var retry = function(currentRetryCount) {
+    if (typeof(currentRetryCount) === 'number') {
+      if (currentRetryCount >= <%= retry_count %>)
+        return false;
+
+      _listener(currentRetryCount + 1);
+      return true;
+    }
+
+    _listener(1);
+    return true;
+  }
+  <% end %>
 
   <% if turbolinks %>
   document.addEventListener("turbolinks:load", function (e) {

--- a/lib/render_async/view_helper.rb
+++ b/lib/render_async/view_helper.rb
@@ -28,6 +28,7 @@ module RenderAsync
       headers = options.delete(:headers) || {}
       error_message = options.delete(:error_message)
       error_event_name = options.delete(:error_event_name)
+      retry_count = options.delete(:retry_count) || 0
 
       render 'render_async/render_async', html_element_name: html_element_name,
                                           container_id: container_id,
@@ -40,7 +41,8 @@ module RenderAsync
                                           data: data,
                                           headers: headers,
                                           error_message: error_message,
-                                          error_event_name: error_event_name
+                                          error_event_name: error_event_name,
+                                          retry_count: retry_count
     end
 
     private

--- a/spec/render_async/view_helper_spec.rb
+++ b/spec/render_async/view_helper_spec.rb
@@ -53,7 +53,8 @@ describe RenderAsync::ViewHelper do
             data: nil,
             headers: {},
             error_message: nil,
-            error_event_name: nil
+            error_event_name: nil,
+            retry_count: 0
           }
         )
 
@@ -83,7 +84,8 @@ describe RenderAsync::ViewHelper do
             data: nil,
             headers: {},
             error_message: nil,
-            error_event_name: nil
+            error_event_name: nil,
+            retry_count: 0
           }
         )
 
@@ -107,7 +109,8 @@ describe RenderAsync::ViewHelper do
             data: nil,
             headers: {},
             error_message: nil,
-            error_event_name: nil
+            error_event_name: nil,
+            retry_count: 0
           }
         )
 
@@ -131,7 +134,8 @@ describe RenderAsync::ViewHelper do
             data: nil,
             headers: {},
             error_message: nil,
-            error_event_name: nil
+            error_event_name: nil,
+            retry_count: 0
           }
         )
 
@@ -155,7 +159,8 @@ describe RenderAsync::ViewHelper do
             data: nil,
             headers: {},
             error_message: nil,
-            error_event_name: nil
+            error_event_name: nil,
+            retry_count: 0
           }
         )
 
@@ -179,7 +184,8 @@ describe RenderAsync::ViewHelper do
             data: nil,
             headers: {},
             error_message: nil,
-            error_event_name: nil
+            error_event_name: nil,
+            retry_count: 0
           }
         )
 
@@ -203,7 +209,8 @@ describe RenderAsync::ViewHelper do
             data: nil,
             headers: {},
             error_message: nil,
-            error_event_name: nil
+            error_event_name: nil,
+            retry_count: 0
           }
         )
 
@@ -233,7 +240,8 @@ describe RenderAsync::ViewHelper do
             data: nil,
             headers: {},
             error_message: nil,
-            error_event_name: nil
+            error_event_name: nil,
+            retry_count: 0
           }
         )
 
@@ -241,7 +249,7 @@ describe RenderAsync::ViewHelper do
       end
     end
 
-    context "json post request" do
+    context "JSON POST request" do
       it "renders render_async partial with proper parameters" do
         expect(helper).to receive(:render).with(
           "render_async/render_async",
@@ -257,7 +265,8 @@ describe RenderAsync::ViewHelper do
             data: { 'foor' => 'bar' }.to_json,
             headers: { 'Content-Type' => 'application/json' },
             error_message: nil,
-            error_event_name: nil
+            error_event_name: nil,
+            retry_count: 0
           }
         )
 
@@ -266,6 +275,34 @@ describe RenderAsync::ViewHelper do
           method: 'POST',
           data: { 'foor' => 'bar' }.to_json,
           headers: { 'Content-Type' => 'application/json' }
+        )
+      end
+    end
+
+    context "retry_count is given" do
+      it "renders render_async partial with proper parameters" do
+        expect(helper).to receive(:render).with(
+          "render_async/render_async",
+          {
+            html_element_name: "div",
+            container_id: /render_async_/,
+            container_class: nil,
+            path: "users",
+            html_options: {},
+            event_name: nil,
+            placeholder: nil,
+            method: 'GET',
+            data: nil,
+            headers: {},
+            error_message: nil,
+            error_event_name: nil,
+            retry_count: 5
+          }
+        )
+
+        helper.render_async(
+          "users",
+          retry_count: 5
         )
       end
     end


### PR DESCRIPTION
This PR solves #46 

Idea here is to dispatch request if `retry_count` is passed to render_async view helper. If request has been called retry_count number of times, and it's failed, then it will finally show error message and dispatch error event if it's defined.

If one the requests gets successfull, it will stop with retrying.