### PR TITLE
Call render_async logic every N seconds

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ Advanced usage includes information on different options, such as:
   - [Passing in an HTML element name](#passing-in-an-html-element-name)
   - [Passing in a placeholder](#passing-in-a-placeholder)
   - [Passing in an event name](#passing-in-an-event-name)
+  - [Polling](#polling)
   - [Handling errors](#handling-errors)
   - [Caching](#caching)
   - [Doing non-GET requests](#doing-non-get-requests)
@@ -232,6 +233,25 @@ document.addEventListener("users-loaded", function() {
 
 NOTE: Dispatching events is also supported for older browsers that don't
 support Event constructor.
+
+### Polling
+
+You can call `render_async` with interval argument. This will make render_async
+call specified path at specified interval.
+
+By doing this:
+```erb
+<%= render_async comments_path, interval: 5000 %>
+```
+You are telling `render_async` to fetch comments_path every 5 seconds.
+
+This can be handy if you want to enable polling for a specific URL.
+
+NOTE: By passing interval to `render_async`, initial container element
+will remain in HTML tree, it will not be replaced with request response.
+You can handle how that container element is rendered and its style by 
+[passing in an HTML element name](#passing-in-an-html-element-name) and 
+[HTML element class](#passing-in-a-container-class-name).
 
 ### Handling errors
 

--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ Advanced usage includes information on different options, such as:
   - [Passing in an HTML element name](#passing-in-an-html-element-name)
   - [Passing in a placeholder](#passing-in-a-placeholder)
   - [Passing in an event name](#passing-in-an-event-name)
+  - [Retry on failure](#retry-on-failure)
   - [Polling](#polling)
   - [Handling errors](#handling-errors)
   - [Caching](#caching)
@@ -233,6 +234,20 @@ document.addEventListener("users-loaded", function() {
 
 NOTE: Dispatching events is also supported for older browsers that don't
 support Event constructor.
+
+### Retry on failure
+
+`render_async` can retry your requests if they fail for some reason.
+
+If you want `render_async` to retry a request for number of times, you can do
+this:
+```erb
+<%= render_async users_path, retry_count: 5, error_message: "Couldn't fetch it" %>
+```
+
+Now render_async will retry `users_path` for 5 times. If it succedes in
+between, it will stop with dispatching requests. If it fails after 5 times,
+it will show an [error message](#handling-errors) which you need to specify.
 
 ### Polling
 

--- a/README.md
+++ b/README.md
@@ -249,6 +249,9 @@ Now render_async will retry `users_path` for 5 times. If it succedes in
 between, it will stop with dispatching requests. If it fails after 5 times,
 it will show an [error message](#handling-errors) which you need to specify.
 
+This can show useful when you know your requests often fail, and you don't want
+to refresh the whole page just to retry them.
+
 ### Polling
 
 You can call `render_async` with interval argument. This will make render_async

--- a/app/views/render_async/_render_async.html.erb
+++ b/app/views/render_async/_render_async.html.erb
@@ -19,6 +19,7 @@
                             error_message: error_message,
                             error_event_name: error_event_name,
                             retry_count: retry_count,
+                            interval: interval,
                             turbolinks: RenderAsync.configuration.turbolinks } %>
     <% else %>
       <%= render partial: 'render_async/request_vanilla',
@@ -32,6 +33,7 @@
                             error_message: error_message,
                             error_event_name: error_event_name,
                             retry_count: retry_count,
+                            interval: interval,
                             turbolinks: RenderAsync.configuration.turbolinks } %>
     <% end %>
   <% end %>

--- a/app/views/render_async/_request_jquery.js.erb
+++ b/app/views/render_async/_request_jquery.js.erb
@@ -18,7 +18,12 @@ if (window.jQuery) {
         data: "<%= escape_javascript(data.to_s.html_safe) %>",
         headers: headers
       }).done(function(response) {
-        $("#<%= container_id %>").replaceWith(response);
+        <% if interval %>
+          $("#<%= container_id %>").empty();
+          $("#<%= container_id %>").append(response);
+        <% else %>
+          $("#<%= container_id %>").replaceWith(response);
+        <% end %>
 
         <% if event_name.present? %>
           var event = undefined;
@@ -70,6 +75,11 @@ if (window.jQuery) {
 
     <% if turbolinks %>
     $(document).one('turbolinks:load', _listener);
+    <% elsif interval %>
+    var _intervalFunction = function() {
+      setInterval(_listener, <%= interval %>)
+    }
+    $(document).ready(_intervalFunction)
     <% else %>
     $(document).ready(_listener);
     <% end %>

--- a/app/views/render_async/_request_jquery.js.erb
+++ b/app/views/render_async/_request_jquery.js.erb
@@ -77,9 +77,10 @@ if (window.jQuery) {
     $(document).one('turbolinks:load', _listener);
     <% elsif interval %>
     var _intervalFunction = function() {
-      setInterval(_listener, <%= interval %>)
+      _listener();
+      setInterval(_listener, <%= interval %>);
     }
-    $(document).ready(_intervalFunction)
+    $(document).ready(_intervalFunction);
     <% else %>
     $(document).ready(_listener);
     <% end %>

--- a/app/views/render_async/_request_vanilla.js.erb
+++ b/app/views/render_async/_request_vanilla.js.erb
@@ -26,7 +26,11 @@
       if (request.readyState === 4) {
         if (request.status >= SUCCESS && request.status < ERROR) {
           var container = document.getElementById('<%= container_id %>');
+          <% if interval %>
+          container.innerHTML = request.response;
+          <% else %>
           container.outerHTML = request.response;
+          <% end %>
 
           <% if event_name.present? %>
             var event = undefined;
@@ -87,6 +91,11 @@
     e.target.removeEventListener(e.type, arguments.callee);
     _listener.call(this);
   });
+  <% elsif interval %>
+  var _intervalFunction = function() {
+    setInterval(_listener, <%= interval %>)
+  }
+  document.addEventListener("DOMContentLoaded", _intervalFunction);
   <% else %>
   document.addEventListener("DOMContentLoaded", _listener);
   <% end %>

--- a/app/views/render_async/_request_vanilla.js.erb
+++ b/app/views/render_async/_request_vanilla.js.erb
@@ -93,7 +93,8 @@
   });
   <% elsif interval %>
   var _intervalFunction = function() {
-    setInterval(_listener, <%= interval %>)
+    _listener();
+    setInterval(_listener, <%= interval %>);
   }
   document.addEventListener("DOMContentLoaded", _intervalFunction);
   <% else %>

--- a/lib/render_async/view_helper.rb
+++ b/lib/render_async/view_helper.rb
@@ -29,6 +29,7 @@ module RenderAsync
       error_message = options.delete(:error_message)
       error_event_name = options.delete(:error_event_name)
       retry_count = options.delete(:retry_count) || 0
+      interval = options.delete(:interval)
 
       render 'render_async/render_async', html_element_name: html_element_name,
                                           container_id: container_id,
@@ -42,7 +43,8 @@ module RenderAsync
                                           headers: headers,
                                           error_message: error_message,
                                           error_event_name: error_event_name,
-                                          retry_count: retry_count
+                                          retry_count: retry_count,
+                                          interval: interval
     end
 
     private

--- a/spec/render_async/view_helper_spec.rb
+++ b/spec/render_async/view_helper_spec.rb
@@ -54,7 +54,8 @@ describe RenderAsync::ViewHelper do
             headers: {},
             error_message: nil,
             error_event_name: nil,
-            retry_count: 0
+            retry_count: 0,
+            interval: nil
           }
         )
 
@@ -85,7 +86,8 @@ describe RenderAsync::ViewHelper do
             headers: {},
             error_message: nil,
             error_event_name: nil,
-            retry_count: 0
+            retry_count: 0,
+            interval: nil
           }
         )
 
@@ -110,7 +112,8 @@ describe RenderAsync::ViewHelper do
             headers: {},
             error_message: nil,
             error_event_name: nil,
-            retry_count: 0
+            retry_count: 0,
+            interval: nil
           }
         )
 
@@ -135,7 +138,8 @@ describe RenderAsync::ViewHelper do
             headers: {},
             error_message: nil,
             error_event_name: nil,
-            retry_count: 0
+            retry_count: 0,
+            interval: nil
           }
         )
 
@@ -160,7 +164,8 @@ describe RenderAsync::ViewHelper do
             headers: {},
             error_message: nil,
             error_event_name: nil,
-            retry_count: 0
+            retry_count: 0,
+            interval: nil
           }
         )
 
@@ -185,7 +190,8 @@ describe RenderAsync::ViewHelper do
             headers: {},
             error_message: nil,
             error_event_name: nil,
-            retry_count: 0
+            retry_count: 0,
+            interval: nil
           }
         )
 
@@ -210,7 +216,8 @@ describe RenderAsync::ViewHelper do
             headers: {},
             error_message: nil,
             error_event_name: nil,
-            retry_count: 0
+            retry_count: 0,
+            interval: nil
           }
         )
 
@@ -241,7 +248,8 @@ describe RenderAsync::ViewHelper do
             headers: {},
             error_message: nil,
             error_event_name: nil,
-            retry_count: 0
+            retry_count: 0,
+            interval: nil
           }
         )
 
@@ -266,7 +274,8 @@ describe RenderAsync::ViewHelper do
             headers: { 'Content-Type' => 'application/json' },
             error_message: nil,
             error_event_name: nil,
-            retry_count: 0
+            retry_count: 0,
+            interval: nil
           }
         )
 
@@ -296,13 +305,43 @@ describe RenderAsync::ViewHelper do
             headers: {},
             error_message: nil,
             error_event_name: nil,
-            retry_count: 5
+            retry_count: 5,
+            interval: nil
           }
         )
 
         helper.render_async(
           "users",
           retry_count: 5
+        )
+      end
+    end
+
+    context "interval is given" do
+      it "renders render_async partial with proper parameters" do
+        expect(helper).to receive(:render).with(
+          "render_async/render_async",
+          {
+            html_element_name: "div",
+            container_id: /render_async_/,
+            container_class: nil,
+            path: "users",
+            html_options: {},
+            event_name: nil,
+            placeholder: nil,
+            method: 'GET',
+            data: nil,
+            headers: {},
+            error_message: nil,
+            error_event_name: nil,
+            retry_count: 0,
+            interval: 5000
+          }
+        )
+
+        helper.render_async(
+          "users",
+          interval: 5000
         )
       end
     end


### PR DESCRIPTION
Closes https://github.com/renderedtext/render_async/issues/67

It loads the desired path immediately, and then after specified number of milliseconds passed in as `interval` to render_async.

You can use interval like this:
```erb
<%= render_async comments_path, interval: 1000 %>
```

It will fetch comments_path every 1 second. Note that the initial render_async container won't be replaced when using interval. 

Reason for NOT replacing initial container is that render_async needs to have an ID of the container to render the request response.