### PR TITLE
Use double quotes for displaying error message

### DIFF
--- a/app/views/render_async/_request_jquery.js.erb
+++ b/app/views/render_async/_request_jquery.js.erb
@@ -43,7 +43,7 @@ if (window.jQuery) {
 
         if (skipErrorMessage) return;
 
-        $("#<%= container_id %>").replaceWith('<%= error_message.try(:html_safe) %>');
+        $("#<%= container_id %>").replaceWith("<%= error_message.try(:html_safe) %>");
 
         <% if error_event_name.present? %>
           var event = undefined;

--- a/app/views/render_async/_request_vanilla.js.erb
+++ b/app/views/render_async/_request_vanilla.js.erb
@@ -51,7 +51,7 @@
           if (skipErrorMessage) return;
 
           var container = document.getElementById('<%= container_id %>');
-          container.outerHTML = '<%= error_message.try(:html_safe) %>';
+          container.outerHTML = "<%= error_message.try(:html_safe) %>";
 
           <% if error_event_name.present? %>
             var event = undefined;


### PR DESCRIPTION
It fixes the case when error message has single quotes in it which would cause syntax error in JavaScript.