### PR TITLE
Bump nonce pattern in the README to follow Rails CSP standard

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,21 +133,23 @@ Rendered code in the view:
 `html_options` is an optional hash that gets passed to a Rails'
 `javascript_tag`, to drop HTML tags into the `script` element.
 
-Example of utilizing `html_options` with a `nonce`:
+Example of utilizing `html_options` with a [nonce](https://edgeguides.rubyonrails.org/security.html#content-security-policy):
 ```erb
-<%= render_async users_path, html_options: { nonce: 'lWaaV6eYicpt+oyOfcShYINsz0b70iR+Q1mohZqNaag=' } %>
+<%= render_async users_path, html_options: { nonce: true } %>
 ```
 
 Rendered code in the view:
 ```html
-<div id="render_async_18b8a6cd161499117471">
-</div>
-
-<script nonce="lWaaV6eYicpt+oyOfcShYINsz0b70iR+Q1mohZqNaag=">
+<script nonce="2x012CYGxKgM8qAApxRHxA==">
 //<![CDATA[
   ...
 //]]>
 </script>
+
+...
+
+<div id="render_async_18b8a6cd161499117471" class="">
+</div>
 ```
 
 ### Passing in an HTML element name


### PR DESCRIPTION
hey @nikolalsvk ! Hope all is well.

I was upgrading our pin of this library and noticed that one of the things I contributed to the readme way back when was getting a little stale, so I thought I'd spruce it up a little. This change makes the `html_options` recipe follow more contemporary patterns for how Rails is handling nonces, now that CSPs are built in to Rails more natively.

Also changes it so that it tracks a little closer to what the actual output is these days, I think?

(Incidentally this is something I spent a little bit of time fixing just now 😂 )