### PR TITLE
Add generic "load" and "error" events

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ Advanced usage includes information on different options, such as:
   - [Passing in an HTML element name](#passing-in-an-html-element-name)
   - [Passing in a placeholder](#passing-in-a-placeholder)
   - [Passing in an event name](#passing-in-an-event-name)
+  - [Using events](#using-events)
   - [Retry on failure](#retry-on-failure)
   - [Toggle event](#toggle-event)
   - [Polling](#polling)
@@ -238,6 +239,36 @@ document.addEventListener("users-loaded", function() {
 
 NOTE: Dispatching events is also supported for older browsers that don't
 support Event constructor.
+
+### Using events
+
+`render_async` will fire the event `render_async_load` when an async partial has loaded and rendered on page.
+
+In case there is an error, the event `render_async_error` will fire instead.
+
+This event will fire for all `render_async` partials on the page. For every event, the associated container (DOM node) will be passed along. 
+
+This can be useful to apply javascript to content loaded after the page is ready.
+
+Example of using events:
+
+```js
+// Vanilla javascript
+document.addEventListener('render_async_load', function(event) {
+  console.log('Async partial loaded in this container:', event.container);
+});
+document.addEventListener('render_async_error', function(event) {
+  console.log('Async partial could not load in this container:', event.container);
+});
+
+// with jQuery
+$(document).on('render_async_load', function(event, container) {
+  console.log('Async partial loaded in this container:', container);
+});
+$(document).on('render_async_error', function(event, container) {
+  console.log('Async partial could not load in this container:', container);
+});
+```
 
 ### Retry on failure
 

--- a/app/views/render_async/_request_jquery.js.erb
+++ b/app/views/render_async/_request_jquery.js.erb
@@ -18,12 +18,15 @@ if (window.jQuery) {
         data: "<%= escape_javascript(data.to_s.html_safe) %>",
         headers: headers
       }).done(function(response) {
+        var $container = $("#<%= container_id %>");
         <% if interval %>
-          $("#<%= container_id %>").empty();
-          $("#<%= container_id %>").append(response);
+          $container.empty();
+          $container.append(response);
         <% else %>
-          $("#<%= container_id %>").replaceWith(response);
+          $container.replaceWith(response);
         <% end %>
+
+        $(document).trigger('render_async_load', [$container]);
 
         <% if event_name.present? %>
           var event = undefined;
@@ -43,7 +46,10 @@ if (window.jQuery) {
 
         if (skipErrorMessage) return;
 
-        $("#<%= container_id %>").replaceWith("<%= error_message.try(:html_safe) %>");
+        var $container = $("#<%= container_id %>");
+        $container.replaceWith("<%= error_message.try(:html_safe) %>");
+
+        $(document).trigger('render_async_error', [$container]);
 
         <% if error_event_name.present? %>
           var event = undefined;

--- a/app/views/render_async/_request_vanilla.js.erb
+++ b/app/views/render_async/_request_vanilla.js.erb
@@ -5,6 +5,16 @@
   }
   <% end %>
 
+  function createEvent(name) {
+    if (typeof(Event) === 'function') {
+      event = new Event(name);
+    } else {
+      event = document.createEvent('Event');
+      event.initEvent(name, true, true);
+    }
+    return event
+  }
+    
   var _makeRequest = function(currentRetryCount) {
     var request = new XMLHttpRequest();
     var asyncRequest = true;
@@ -31,15 +41,13 @@
           <% else %>
           container.outerHTML = request.response;
           <% end %>
-
+          
+          var loadEvent = createEvent("render_async_load");
+          loadEvent.container = container;
+          document.dispatchEvent(loadEvent);
+          
           <% if event_name.present? %>
-            var event = undefined;
-            if (typeof(Event) === 'function') {
-              event = new Event("<%= event_name %>");
-            } else {
-              event = document.createEvent('Event');
-              event.initEvent('<%= event_name %>', true, true);
-            }
+            var event = createEvent("<%= event_name %>");
             document.dispatchEvent(event);
           <% end %>
         } else {
@@ -54,13 +62,7 @@
           container.outerHTML = "<%= error_message.try(:html_safe) %>";
 
           <% if error_event_name.present? %>
-            var event = undefined;
-            if (typeof(Event) === 'function') {
-              event = new Event("<%= error_event_name %>");
-            } else {
-              event = document.createEvent('Event');
-              event.initEvent('<%= error_event_name %>', true, true);
-            }
+            var event = createEvent("<%= error_event_name %>");
             document.dispatchEvent(event);
           <% end %>
         }

--- a/app/views/render_async/_request_vanilla.js.erb
+++ b/app/views/render_async/_request_vanilla.js.erb
@@ -60,7 +60,7 @@
           if (skipErrorMessage) return;
 
           var container = document.getElementById('<%= container_id %>');
-          container.outerHTML = "<%= error_message.try(:html_safe) %>";
+          container.outerHTML = '<%= error_message.try(:html_safe) %>';
 
           <% if error_event_name.present? %>
             var event = createEvent("<%= error_event_name %>");

--- a/app/views/render_async/_request_vanilla.js.erb
+++ b/app/views/render_async/_request_vanilla.js.erb
@@ -6,6 +6,7 @@
   <% end %>
 
   function createEvent(name) {
+    var event = null;
     if (typeof(Event) === 'function') {
       event = new Event(name);
     } else {

--- a/app/views/render_async/_request_vanilla.js.erb
+++ b/app/views/render_async/_request_vanilla.js.erb
@@ -4,7 +4,6 @@
     return;
   }
   <% end %>
-
   function createEvent(name) {
     var event = null;
     if (typeof(Event) === 'function') {
@@ -13,9 +12,9 @@
       event = document.createEvent('Event');
       event.initEvent(name, true, true);
     }
-    return event
+    return event;
   }
-    
+
   var _makeRequest = function(currentRetryCount) {
     var request = new XMLHttpRequest();
     var asyncRequest = true;
@@ -42,13 +41,13 @@
           <% else %>
           container.outerHTML = request.response;
           <% end %>
-          
-          var loadEvent = createEvent("render_async_load");
+
+          var loadEvent = createEvent('render_async_load');
           loadEvent.container = container;
           document.dispatchEvent(loadEvent);
-          
+
           <% if event_name.present? %>
-            var event = createEvent("<%= event_name %>");
+            var event = createEvent('<%= event_name %>');
             document.dispatchEvent(event);
           <% end %>
         } else {
@@ -62,8 +61,12 @@
           var container = document.getElementById('<%= container_id %>');
           container.outerHTML = "<%= error_message.try(:html_safe) %>";
 
+          var errorEvent = createEvent('render_async_error');
+          errorEvent.container = container;
+          document.dispatchEvent(errorEvent);
+
           <% if error_event_name.present? %>
-            var event = createEvent("<%= error_event_name %>");
+            var event = createEvent('<%= error_event_name %>');
             document.dispatchEvent(event);
           <% end %>
         }


### PR DESCRIPTION
This PR adds 2 generic javascript events: `render_async_load` and `render_async_error`.

**Use case**
In a project with a lot of `render_async`, you might want to apply javascript to all content, even content loaded asynchronously. Adding a custom event name for every use of `render_async` is not practical, so this generic event allows to handle all `render_async` in 1 event handler.
