### PR TITLE
Attach container to dispatched events

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ Advanced usage includes information on different options, such as:
   - [Passing in an HTML element name](#passing-in-an-html-element-name)
   - [Passing in a placeholder](#passing-in-a-placeholder)
   - [Passing in an event name](#passing-in-an-event-name)
-  - [Using events](#using-events)
+  - [Using default events](#using-default-events)
   - [Retry on failure](#retry-on-failure)
   - [Toggle event](#toggle-event)
   - [Polling](#polling)
@@ -211,6 +211,9 @@ event after it's done with fetching and rendering request content to HTML.
 This can be useful to have if you want to add some JavaScript functionality
 after your partial is loaded through `render_async`.
 
+You can also access the associated container (DOM node) in the event object
+that gets emitted.
+
 Example of passing it to `render_async`:
 ```erb
 <%= render_async users_path, event_name: "users-loaded" %>
@@ -230,25 +233,28 @@ Rendered code in view:
 </script>
 ```
 
-Then, in your JS, you could do something like this:
+Then, in your JavaScript code, you could do something like this:
 ```javascript
-document.addEventListener("users-loaded", function() {
-  console.log("Users have loaded!");
+document.addEventListener("users-loaded", function(event) {
+  console.log("Users have loaded!", event.container); // Access the container which loaded the users
 });
 ```
 
 NOTE: Dispatching events is also supported for older browsers that don't
 support Event constructor.
 
-### Using events
+### Using default events
 
-`render_async` will fire the event `render_async_load` when an async partial has loaded and rendered on page.
+`render_async` will fire the event `render_async_load` when an async partial
+has loaded and rendered on page.
 
 In case there is an error, the event `render_async_error` will fire instead.
 
-This event will fire for all `render_async` partials on the page. For every event, the associated container (DOM node) will be passed along. 
+This event will fire for all `render_async` partials on the page. For every
+event, the associated container (DOM node) will be passed along.
 
-This can be useful to apply javascript to content loaded after the page is ready.
+This can be useful to apply JavaScript to content loaded after the page is
+ready.
 
 Example of using events:
 
@@ -280,7 +286,7 @@ this:
 <%= render_async users_path, retry_count: 5, error_message: "Couldn't fetch it" %>
 ```
 
-Now render_async will retry `users_path` for 5 times. If it succedes in
+Now render_async will retry `users_path` for 5 times. If it succeeds in
 between, it will stop with dispatching requests. If it fails after 5 times,
 it will show an [error message](#handling-errors) which you need to specify.
 
@@ -301,7 +307,7 @@ do this by doing the following:
 ```
 
 This will trigger `render_async` to load the `comments_path` when you click the `#details-button` element.
-If you wannt to remove event once it's triggered, you can pass `once: true` in the toggle options. 
+If you want to remove event once it's triggered, you can pass `once: true` in the toggle options.
 The `once` option is false by default.
 
 You can also pass in a placeholder before the `render_async` is triggered. That
@@ -422,7 +428,7 @@ away from, and then back to, a page with a `render_async` call on it. This will
 likely show up as an empty div.
 
 If you're using Turbolinks 5 or higher, you can resolve this by setting Turbolinks
-configurtion of `render_async` to true:
+configuration of `render_async` to true:
 
 ```rb
 RenderAsync.configure do |config|

--- a/app/views/render_async/_request_jquery.js.erb
+++ b/app/views/render_async/_request_jquery.js.erb
@@ -5,6 +5,17 @@ if (window.jQuery) {
       return;
     }
     <% end %>
+    function createEvent(name, container) {
+      var event = undefined;
+      if (typeof(Event) === 'function') {
+        event = new Event(name);
+      } else {
+        event = document.createEvent('Event');
+        event.initEvent(name, true, true);
+      }
+      event.container = container
+      return event;
+    }
 
     var _makeRequest = function(currentRetryCount) {
       var headers = <%= headers.to_json.html_safe %>;
@@ -18,24 +29,19 @@ if (window.jQuery) {
         data: "<%= escape_javascript(data.to_s.html_safe) %>",
         headers: headers
       }).done(function(response) {
-        var $container = $("#<%= container_id %>");
+        var container = $("#<%= container_id %>");
         <% if interval %>
-          $container.empty();
-          $container.append(response);
+          container.empty();
+          container.append(response);
         <% else %>
-          $container.replaceWith(response);
+          container.replaceWith(response);
         <% end %>
 
-        $(document).trigger('render_async_load', [$container]);
+        var loadEvent = createEvent('render_async_load', container);
+        document.dispatchEvent(loadEvent);
 
         <% if event_name.present? %>
-          var event = undefined;
-          if (typeof(Event) === 'function') {
-            event = new Event("<%= event_name %>");
-          } else {
-            event = document.createEvent('Event');
-            event.initEvent('<%= event_name %>', true, true);
-          }
+          var event = createEvent("<%= event_name %>", container)
           document.dispatchEvent(event);
         <% end %>
       }).fail(function(response) {
@@ -46,19 +52,15 @@ if (window.jQuery) {
 
         if (skipErrorMessage) return;
 
-        var $container = $("#<%= container_id %>");
-        $container.replaceWith("<%= error_message.try(:html_safe) %>");
+        var container = $("#<%= container_id %>");
+        container.replaceWith("<%= error_message.try(:html_safe) %>");
 
-        $(document).trigger('render_async_error', [$container]);
+        var errorEvent = createEvent('render_async_error', container);
+        errorEvent.container = container;
+        document.dispatchEvent(errorEvent);
 
         <% if error_event_name.present? %>
-          var event = undefined;
-          if (typeof(Event) === 'function') {
-            event = new Event("<%= error_event_name %>");
-          } else {
-            event = document.createEvent('Event');
-            event.initEvent('<%= error_event_name %>', true, true);
-          }
+          var event = createEvent("<%= error_event_name %>", container)
           document.dispatchEvent(event);
         <% end %>
       });

--- a/app/views/render_async/_request_vanilla.js.erb
+++ b/app/views/render_async/_request_vanilla.js.erb
@@ -101,7 +101,7 @@
   <% end %>
 
   <% if toggle %>
-  var selectors = document.querySelectorAll('<%= toggle[:selector] %>');
+  var selectors = document.querySelectorAll('<%= toggle[:selector] %>'), i;
   var handler = function(event) {
     event.preventDefault();
     if (typeof(_interval) === 'number') {
@@ -115,9 +115,9 @@
     <% end %>
   };
 
-  [...selectors].forEach(function(selector) {
-    selector.addEventListener('<%= toggle[:event] || 'click' %>', handler)
-  });
+  for (i = 0; i < selectors.length; ++i) {
+    selectors[i].addEventListener('<%= toggle[:event] || 'click' %>', handler)
+  }
   <% end %>
 
   <% if turbolinks && !toggle %>

--- a/app/views/render_async/_request_vanilla.js.erb
+++ b/app/views/render_async/_request_vanilla.js.erb
@@ -5,7 +5,7 @@
   }
   <% end %>
   function createEvent(name) {
-    var event = null;
+    var event = undefined;
     if (typeof(Event) === 'function') {
       event = new Event(name);
     } else {
@@ -42,12 +42,11 @@
           container.outerHTML = request.response;
           <% end %>
 
-          var loadEvent = createEvent('render_async_load');
-          loadEvent.container = container;
+          var loadEvent = createEvent('render_async_load', container);
           document.dispatchEvent(loadEvent);
 
           <% if event_name.present? %>
-            var event = createEvent('<%= event_name %>');
+            var event = createEvent('<%= event_name %>', container);
             document.dispatchEvent(event);
           <% end %>
         } else {
@@ -61,12 +60,11 @@
           var container = document.getElementById('<%= container_id %>');
           container.outerHTML = '<%= error_message.try(:html_safe) %>';
 
-          var errorEvent = createEvent('render_async_error');
-          errorEvent.container = container;
+          var errorEvent = createEvent('render_async_error', container);
           document.dispatchEvent(errorEvent);
 
           <% if error_event_name.present? %>
-            var event = createEvent('<%= error_event_name %>');
+            var event = createEvent('<%= error_event_name %>', container);
             document.dispatchEvent(event);
           <% end %>
         }


### PR DESCRIPTION
Related to https://github.com/renderedtext/render_async/issues/81

Fine-tuning awesome contribution from https://github.com/renderedtext/render_async/pull/103

Now you can access the HTML element where your request content loaded like this:

```js
document.addEventListener('render_async_load', function(event) {
  console.log('Async partial loaded in this container:', event.container);
});
```