### PR TITLE
Add X-Requested-With header in Vanilla JS

### DIFF
--- a/app/views/render_async/_request_vanilla.js.erb
+++ b/app/views/render_async/_request_vanilla.js.erb
@@ -44,6 +44,8 @@
       request.setRequestHeader(key, headers[key]);
     });
 
+    request.setRequestHeader('X-Requested-With', 'XMLHttpRequest');
+
     request.onreadystatechange = function() {
       if (request.readyState === 4) {
         if (request.status >= SUCCESS && request.status < ERROR) {


### PR DESCRIPTION
Closes https://github.com/renderedtext/render_async/issues/72

The 'X-Requested-With' is missing when you use `XMLHttpRequest` and this was the issue in #72.