### PR TITLE
Remove interval after Turbolinks visit event

### DIFF
--- a/app/views/render_async/_request_jquery.js.erb
+++ b/app/views/render_async/_request_jquery.js.erb
@@ -127,5 +127,5 @@ if (window.jQuery) {
     <% end %>
   }(jQuery));
 } else {
-  console.warn("Looks like you've enabled jQuery for render_async, but jQuery is not defined");
+  console.warn("Looks like you've enabled jQuery for render_async, but jQuery is not defined on the window object");
 };

--- a/app/views/render_async/_request_jquery.js.erb
+++ b/app/views/render_async/_request_jquery.js.erb
@@ -91,12 +91,22 @@ if (window.jQuery) {
 
     var _renderAsyncFunction = _makeRequest;
 
-    <% if interval %>
     var _interval;
+    <% if interval %>
     var _renderAsyncFunction = function() {
       _makeRequest();
       _interval = setInterval(_makeRequest, <%= interval %>);
     }
+
+    <% if turbolinks %>
+    $(document).one('turbolinks:visit', function() {
+      if (typeof(_interval) === 'number') {
+        console.log('clearing the interval in jQuery part')
+        clearInterval(_interval)
+        _interval = undefined;
+      }
+    });
+    <% end %>
     <% end %>
 
     <% if toggle %>
@@ -111,9 +121,7 @@ if (window.jQuery) {
       });
     }
 
-    //_runAfterDocumentLoaded(_setUpToggle)
-    // RUN IT NOW DP
-    _setUpToggle();
+    _runAfterDocumentLoaded(_setUpToggle);
     <% elsif !toggle %>
     _runAfterDocumentLoaded(_renderAsyncFunction)
     <% end %>

--- a/app/views/render_async/_request_vanilla.js.erb
+++ b/app/views/render_async/_request_vanilla.js.erb
@@ -74,7 +74,6 @@
           var container = document.getElementById('<%= container_id %>');
           container.outerHTML = '<%= error_message.try(:html_safe) %>';
 
-          console.log(container)
           var errorEvent = createEvent('render_async_error', container);
           document.dispatchEvent(errorEvent);
 
@@ -107,17 +106,27 @@
 
   var _renderAsyncFunction = _makeRequest;
 
-  <% if interval %>
   var _interval;
+  <% if interval %>
   var _renderAsyncFunction = function() {
     _makeRequest();
     _interval = setInterval(_makeRequest, <%= interval %>);
   }
+
+  <% if turbolinks %>
+  document.addEventListener("turbolinks:visit", function(e) {
+    if (typeof(_interval) === 'number') {
+      console.log('clearing the interval')
+      clearInterval(_interval);
+      _interval = undefined;
+    }
+  });
+  <% end %>
   <% end %>
 
   <% if toggle %>
   function _setUpToggle() {
-    var selectors = document.querySelectorAll('<%= toggle[:selector] %>'), i;
+    var selectors = document.querySelectorAll('<%= toggle[:selector] %>');
     var handler = function(event) {
       if (typeof(_interval) === 'number') {
         clearInterval(_interval);
@@ -130,12 +139,12 @@
       <% end %>
     };
 
-    for (i = 0; i < selectors.length; ++i) {
+    for (var i = 0; i < selectors.length; ++i) {
       selectors[i].addEventListener('<%= toggle[:event] || 'click' %>', handler)
     }
   }
 
-  _setUpToggle();
+  _runAfterDocumentLoaded(_setUpToggle);
   <% elsif !toggle %>
   _runAfterDocumentLoaded(_renderAsyncFunction);
   <% end %>


### PR DESCRIPTION
Closes https://github.com/renderedtext/render_async/issues/100

Issue #100 was happening when you navigate by history or you visit a Turbolinks managed link. The interval was not being cleared after this and the polling kept on going forever.