### PR TITLE
Call render_async logic if document state is ready or interactive

### DIFF
--- a/app/views/render_async/_request_jquery.js.erb
+++ b/app/views/render_async/_request_jquery.js.erb
@@ -18,11 +18,16 @@ if (window.jQuery) {
     }
 
     function _runAfterDocumentLoaded(callback) {
-      <% if turbolinks %>
-      $(document).one('turbolinks:load', callback);
-      <% else %>
-      $(document).ready(callback);
-      <% end %>
+      if (document.readyState === 'complete' || document.readyState === 'interactive') {
+        // Handle a case where nested partials get loaded after the document loads
+        callback();
+      } else {
+        <% if turbolinks %>
+        $(document).one('turbolinks:load', callback);
+        <% else %>
+        $(document).ready(callback);
+        <% end %>
+      }
     }
 
     function _makeRequest(currentRetryCount) {


### PR DESCRIPTION
Based on the comment from here https://github.com/renderedtext/render_async/issues/70#issuecomment-626219698, nested partials were not loading with Turbolinks. 

By tracking whether the document state is 'completed' or 'interactive', nested render_async logic will perform instead of waiting for `turbolinks:load` event like it does on the first-page load.