### PR TITLE
Allow a custom content_for name

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ Advanced usage includes information on different options, such as:
   - [Using with Turbolinks](#using-with-turbolinks)
   - [Using with respond_to and JS format](#using-with-respond_to-and-js-format)
   - [Nested Async Renders](#nested-async-renders)
+  - [Customizing the content_for Name](#customizing-the-content-for-name)
   - [Configuration](#configuration)
 
 ### Passing in a container ID
@@ -504,6 +505,18 @@ For example:
 </div>
 
 <%= content_for :render_async %>
+```
+
+### Customizing the content_for Name
+
+The `content_for` name may be customized by passing the `content_for_name` option to `render_async`.
+This option is especially useful when doing nested async renders to better control the location of the injected Javascript.
+
+For example:
+```erb
+<%= render_async comment_stats_path, content_for_name: :render_async_comment_stats %>
+
+<%= content_for :render_async_comment_stats %>
 ```
 
 ### Configuration

--- a/app/views/render_async/_render_async.html.erb
+++ b/app/views/render_async/_render_async.html.erb
@@ -5,7 +5,7 @@
   <%= placeholder %>
 </<%= html_element_name %>>
 
-<% content_for :render_async do %>
+<% content_for local_assigns.has_key?(:content_for_name) ? content_for_name : :render_async do %>
   <%= javascript_tag html_options do %>
     <% if RenderAsync.configuration.jquery %>
       <%= render partial: 'render_async/request_jquery',

--- a/lib/render_async/view_helper.rb
+++ b/lib/render_async/view_helper.rb
@@ -31,7 +31,8 @@ module RenderAsync
                                           **request_options(options),
                                           **error_handling_options(options),
                                           retry_count: retry_count,
-                                          **polling_options(options)
+                                          **polling_options(options),
+                                          **content_for_options(options)
     end
 
     private
@@ -56,6 +57,12 @@ module RenderAsync
     def polling_options(options)
       { interval: options[:interval],
         toggle: options[:toggle] }
+    end
+
+    def content_for_options(options)
+      {
+        content_for_name: options[:content_for_name] || :render_async
+      }
     end
 
     private

--- a/spec/render_async/view_helper_spec.rb
+++ b/spec/render_async/view_helper_spec.rb
@@ -56,7 +56,8 @@ describe RenderAsync::ViewHelper do
             error_message: nil,
             error_event_name: nil,
             retry_count: 0,
-            interval: nil
+            interval: nil,
+            content_for_name: :render_async
           }
         )
 
@@ -89,7 +90,8 @@ describe RenderAsync::ViewHelper do
             error_message: nil,
             error_event_name: nil,
             retry_count: 0,
-            interval: nil
+            interval: nil,
+            content_for_name: :render_async
           }
         )
 
@@ -116,7 +118,8 @@ describe RenderAsync::ViewHelper do
             error_message: nil,
             error_event_name: nil,
             retry_count: 0,
-            interval: nil
+            interval: nil,
+            content_for_name: :render_async
           }
         )
 
@@ -143,7 +146,8 @@ describe RenderAsync::ViewHelper do
             error_message: nil,
             error_event_name: nil,
             retry_count: 0,
-            interval: nil
+            interval: nil,
+            content_for_name: :render_async
           }
         )
 
@@ -170,7 +174,8 @@ describe RenderAsync::ViewHelper do
             error_message: nil,
             error_event_name: nil,
             retry_count: 0,
-            interval: nil
+            interval: nil,
+            content_for_name: :render_async
           }
         )
 
@@ -197,7 +202,8 @@ describe RenderAsync::ViewHelper do
             error_message: nil,
             error_event_name: nil,
             retry_count: 0,
-            interval: nil
+            interval: nil,
+            content_for_name: :render_async
           }
         )
 
@@ -224,7 +230,8 @@ describe RenderAsync::ViewHelper do
             error_message: nil,
             error_event_name: nil,
             retry_count: 0,
-            interval: nil
+            interval: nil,
+            content_for_name: :render_async
           }
         )
 
@@ -251,7 +258,8 @@ describe RenderAsync::ViewHelper do
             error_message: nil,
             error_event_name: nil,
             retry_count: 0,
-            interval: nil
+            interval: nil,
+            content_for_name: :render_async
           }
         )
 
@@ -284,7 +292,8 @@ describe RenderAsync::ViewHelper do
             error_message: nil,
             error_event_name: nil,
             retry_count: 0,
-            interval: nil
+            interval: nil,
+            content_for_name: :render_async
           }
         )
 
@@ -311,7 +320,8 @@ describe RenderAsync::ViewHelper do
             error_message: nil,
             error_event_name: nil,
             retry_count: 0,
-            interval: nil
+            interval: nil,
+            content_for_name: :render_async
           }
         )
 
@@ -343,7 +353,8 @@ describe RenderAsync::ViewHelper do
             error_message: nil,
             error_event_name: nil,
             retry_count: 5,
-            interval: nil
+            interval: nil,
+            content_for_name: :render_async
           }
         )
 
@@ -373,7 +384,8 @@ describe RenderAsync::ViewHelper do
             error_message: nil,
             error_event_name: nil,
             retry_count: 0,
-            interval: 5000
+            interval: 5000,
+            content_for_name: :render_async
           }
         )
 
@@ -383,5 +395,37 @@ describe RenderAsync::ViewHelper do
         )
       end
     end
+
+    context "content_for_name is given" do
+      it "renders render_async partial with proper parameters" do
+        expect(helper).to receive(:render).with(
+          "render_async/render_async",
+          {
+            html_element_name: "div",
+            container_id: /render_async_/,
+            container_class: nil,
+            path: "users",
+            html_options: {},
+            event_name: nil,
+            toggle: nil,
+            placeholder: nil,
+            method: 'GET',
+            data: nil,
+            headers: {},
+            error_message: nil,
+            error_event_name: nil,
+            retry_count: 0,
+            interval: nil,
+            content_for_name: :render_async_other_name
+          }
+        )
+
+        helper.render_async(
+          "users",
+          content_for_name: :render_async_other_name
+        )
+      end
+    end
+
   end
 end


### PR DESCRIPTION
Added an option to control the name used in the content_for call.  
The name defaults to :render_async. 
A custom name may be used to better control the placement of injected Javascript especially when rendering nested async views. 