### PR TITLE
Implement retry after some time feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ than using regular rendering.
 
 It works with Rails and its tools out of the box.
 
-:sparkles: A quick overview of how `render_async` does its magic:
+:sparkles:  A quick overview of how `render_async` does its magic:
 
 1. user visits a page
 2. `render_async` makes an AJAX request on the controller action
@@ -60,6 +60,8 @@ It works with Rails and its tools out of the box.
 
 JavaScript is injected straight into `<%= content_for :render_async %>` so you choose
 where to put it.
+
+:mega:  P.S. Join our [Discord channel](https://discord.gg/SPfbeRm) for help and discussion, and let's make `render_async` even better!
 
 ## :package: Installation
 
@@ -118,6 +120,7 @@ Advanced usage includes information on different options, such as:
   - [Passing in an event name](#passing-in-an-event-name)
   - [Using default events](#using-default-events)
   - [Retry on failure](#retry-on-failure)
+    - [Retry after some time](#retry-after-some-time)
   - [Toggle event](#toggle-event)
     - [Control polling with a toggle](#control-polling-with-a-toggle)
   - [Polling](#polling)
@@ -331,6 +334,39 @@ it will show an [error message](#handling-errors) which you need to specify.
 This can show useful when you know your requests often fail, and you don't want
 to refresh the whole page just to retry them.
 
+#### Retry after some time
+
+If you want to retry requests but with some delay in between the calls, you can
+pass a `retry_delay` option together with `retry_count` like so:
+
+```erb
+<%= render_async users_path,
+                 retry_count: 5,
+                 retry_delay: 2000 %>
+```
+
+This will make `render_async` wait for 2 seconds before retrying after each
+failure. In the end, if the request is still failing after 5th time, it will
+dispatch a [default error event](#using-default-events).
+
+> :candy:  If you are catching an event after an error, you can get `retryCount` from
+the event. `retryCount` will have number of retries it took before the event was dispatched.
+
+Here is an example on how to get `retryCount`:
+
+```erb
+<%= render_async users_path,
+                 retry_count: 5,
+                 retry_delay: 2000,
+                 error_event_name: 'it-failed-badly' %>
+
+<script>
+  document.addEventListener('it-failed-badly', function(event) {
+    console.log("Request failed after " + event.retryCount + " tries!")
+  });
+</script>
+```
+
 ### Toggle event
 
 You can trigger `render_async` loading by clicking or doing another event to a
@@ -382,7 +418,7 @@ You are telling `render_async` to fetch comments_path every 5 seconds.
 
 This can be handy if you want to enable polling for a specific URL.
 
-> :warning: By passing interval to `render_async`, initial container element
+> :warning:  By passing interval to `render_async`, initial container element
 > will remain in HTML tree, it will not be replaced with request response.
 > You can handle how that container element is rendered and its style by
 > [passing in an HTML element name](#passing-in-an-html-element-name) and
@@ -400,7 +436,7 @@ container element. From your code, you can emit following events:
   - 'async-stop' - this will stop polling
   - 'async-start' - this will start polling.
 
-> :bulb: Please note that events need to be dispatched to a render_async container.
+> :bulb:  Please note that events need to be dispatched to a render_async container.
 
 An example of how you can do this looks like this:
 
@@ -538,7 +574,7 @@ If you want, you can tell Turbolinks to reload your `render_async` call as follo
 
 This will reload the whole page with Turbolinks.
 
-> :bulb: Make sure to put `<%= content_for :render_async %>` in your base view file in
+> :bulb:  Make sure to put `<%= content_for :render_async %>` in your base view file in
 the `<head>` and not the `<body>`.
 
 ### Using with respond_to and JS format
@@ -639,11 +675,19 @@ After checking out the repo, run `bin/setup` to install dependencies. Then, run
 prompt that will allow you to experiment. To run integration tests, use
 `bin/integration-tests`.
 
+Got any questions or comments about development (or anything else)?
+Join [render_async's Discord channel](https://discord.gg/SPfbeRm)
+and let's make `render_async` even better!
+
 ## :pray: Contributing
 
 Thank you for considering or deciding to contribute, this is much appreciated!
 Any kind of bug reports and pull requests are encouraged and welcome on GitHub at
 https://github.com/renderedtext/render_async.
+
+Got any issues or difficulties?
+Join [render_async's Discord channel](https://discord.gg/SPfbeRm)
+and let's make `render_async` even better!
 
 ## :memo: License
 

--- a/app/views/render_async/_render_async.html.erb
+++ b/app/views/render_async/_render_async.html.erb
@@ -17,6 +17,7 @@
                   error_message: error_message,
                   error_event_name: error_event_name,
                   retry_count: retry_count,
+                  retry_delay: retry_delay,
                   interval: interval,
                   turbolinks: RenderAsync.configuration.turbolinks } %>
 

--- a/app/views/render_async/_request_jquery.js.erb
+++ b/app/views/render_async/_request_jquery.js.erb
@@ -68,28 +68,37 @@ if (window.jQuery) {
         var container = $("#<%= container_id %>");
         container.replaceWith("<%= error_message.try(:html_safe) %>");
 
-        var errorEvent = createEvent('render_async_error', container);
-        errorEvent.container = container;
-        document.dispatchEvent(errorEvent);
+        var errorEvent = createEvent(
+          "<%= error_event_name || 'render_async_error' %>",
+          container
+        )
+        errorEvent.retryCount = currentRetryCount
 
-        <% if error_event_name.present? %>
-          var event = createEvent("<%= error_event_name %>", container)
-          document.dispatchEvent(event);
-        <% end %>
+        document.dispatchEvent(errorEvent);
       });
     };
 
     <% if retry_count > 0 %>
+    var _retryMakeRequest = _makeRequest
+
+    <% if retry_delay %>
+    _retryMakeRequest = function(currentRetryCount) {
+      setTimeout(function() {
+        _makeRequest(currentRetryCount)
+      }, <%= retry_delay %>)
+    }
+    <% end %>
+
     function retry(currentRetryCount) {
       if (typeof(currentRetryCount) === 'number') {
         if (currentRetryCount >= <%= retry_count %>)
           return false;
 
-        _makeRequest(currentRetryCount + 1);
+        _retryMakeRequest(currentRetryCount + 1);
         return true;
       }
 
-      _makeRequest(1);
+      _retryMakeRequest(1);
       return true;
     }
     <% end %>

--- a/app/views/render_async/_request_vanilla.js.erb
+++ b/app/views/render_async/_request_vanilla.js.erb
@@ -74,13 +74,13 @@
           var container = document.getElementById('<%= container_id %>');
           container.outerHTML = '<%= error_message.try(:html_safe) %>';
 
-          var errorEvent = createEvent('render_async_error', container);
-          document.dispatchEvent(errorEvent);
+          var errorEvent = createEvent(
+            "<%= error_event_name || 'render_async_error' %>",
+            container
+          );
+          errorEvent.retryCount = currentRetryCount
 
-          <% if error_event_name.present? %>
-            var event = createEvent('<%= error_event_name %>', container);
-            document.dispatchEvent(event);
-          <% end %>
+          document.dispatchEvent(errorEvent);
         }
       }
     };
@@ -90,16 +90,25 @@
   };
 
   <% if retry_count > 0 %>
+
+  <% if retry_delay %>
+  _retryMakeRequest = function(currentRetryCount) {
+    setTimeout(function() {
+      _makeRequest(currentRetryCount)
+    }, <%= retry_delay %>)
+  }
+  <% end %>
+
   function retry(currentRetryCount) {
     if (typeof(currentRetryCount) === 'number') {
       if (currentRetryCount >= <%= retry_count %>)
         return false;
 
-      _makeRequest(currentRetryCount + 1);
+      _retryMakeRequest(currentRetryCount + 1);
       return true;
     }
 
-    _makeRequest(1);
+    _retryMakeRequest(1);
     return true;
   }
   <% end %>

--- a/lib/render_async/view_helper.rb
+++ b/lib/render_async/view_helper.rb
@@ -20,7 +20,6 @@ module RenderAsync
     def render_async(path, options = {}, &placeholder)
       event_name = options.delete(:event_name)
       placeholder = capture(&placeholder) if block_given?
-      retry_count = options.delete(:retry_count) || 0
       html_options = options.delete(:html_options) || {}
 
       render 'render_async/render_async', **container_element_options(options),
@@ -30,7 +29,7 @@ module RenderAsync
                                           placeholder: placeholder,
                                           **request_options(options),
                                           **error_handling_options(options),
-                                          retry_count: retry_count,
+                                          **retry_options(options),
                                           **polling_options(options),
                                           **content_for_options(options)
     end
@@ -52,6 +51,13 @@ module RenderAsync
     def error_handling_options(options)
       { error_message: options[:error_message],
         error_event_name: options[:error_event_name] }
+    end
+
+    def retry_options(options)
+      {
+        retry_count: options.delete(:retry_count) || 0,
+        retry_delay: options.delete(:retry_delay)
+      }
     end
 
     def polling_options(options)

--- a/spec/render_async/view_helper_spec.rb
+++ b/spec/render_async/view_helper_spec.rb
@@ -56,6 +56,7 @@ describe RenderAsync::ViewHelper do
             error_message: nil,
             error_event_name: nil,
             retry_count: 0,
+            retry_delay: nil,
             interval: nil,
             content_for_name: :render_async
           }
@@ -90,6 +91,7 @@ describe RenderAsync::ViewHelper do
             error_message: nil,
             error_event_name: nil,
             retry_count: 0,
+            retry_delay: nil,
             interval: nil,
             content_for_name: :render_async
           }
@@ -118,6 +120,7 @@ describe RenderAsync::ViewHelper do
             error_message: nil,
             error_event_name: nil,
             retry_count: 0,
+            retry_delay: nil,
             interval: nil,
             content_for_name: :render_async
           }
@@ -146,6 +149,7 @@ describe RenderAsync::ViewHelper do
             error_message: nil,
             error_event_name: nil,
             retry_count: 0,
+            retry_delay: nil,
             interval: nil,
             content_for_name: :render_async
           }
@@ -174,6 +178,7 @@ describe RenderAsync::ViewHelper do
             error_message: nil,
             error_event_name: nil,
             retry_count: 0,
+            retry_delay: nil,
             interval: nil,
             content_for_name: :render_async
           }
@@ -202,6 +207,7 @@ describe RenderAsync::ViewHelper do
             error_message: nil,
             error_event_name: nil,
             retry_count: 0,
+            retry_delay: nil,
             interval: nil,
             content_for_name: :render_async
           }
@@ -230,6 +236,7 @@ describe RenderAsync::ViewHelper do
             error_message: nil,
             error_event_name: nil,
             retry_count: 0,
+            retry_delay: nil,
             interval: nil,
             content_for_name: :render_async
           }
@@ -258,6 +265,7 @@ describe RenderAsync::ViewHelper do
             error_message: nil,
             error_event_name: nil,
             retry_count: 0,
+            retry_delay: nil,
             interval: nil,
             content_for_name: :render_async
           }
@@ -292,6 +300,7 @@ describe RenderAsync::ViewHelper do
             error_message: nil,
             error_event_name: nil,
             retry_count: 0,
+            retry_delay: nil,
             interval: nil,
             content_for_name: :render_async
           }
@@ -320,6 +329,7 @@ describe RenderAsync::ViewHelper do
             error_message: nil,
             error_event_name: nil,
             retry_count: 0,
+            retry_delay: nil,
             interval: nil,
             content_for_name: :render_async
           }
@@ -353,6 +363,7 @@ describe RenderAsync::ViewHelper do
             error_message: nil,
             error_event_name: nil,
             retry_count: 5,
+            retry_delay: nil,
             interval: nil,
             content_for_name: :render_async
           }
@@ -361,6 +372,38 @@ describe RenderAsync::ViewHelper do
         helper.render_async(
           "users",
           retry_count: 5
+        )
+      end
+    end
+
+    context "retry_delay is given" do
+      it "renders render_async partial with proper parameters" do
+        expect(helper).to receive(:render).with(
+          "render_async/render_async",
+          {
+            html_element_name: "div",
+            container_id: /render_async_/,
+            container_class: nil,
+            path: "users",
+            html_options: {},
+            event_name: nil,
+            toggle: nil,
+            placeholder: nil,
+            method: 'GET',
+            data: nil,
+            headers: {},
+            error_message: nil,
+            error_event_name: nil,
+            retry_count: 0,
+            retry_delay: 3000,
+            interval: nil,
+            content_for_name: :render_async
+          }
+        )
+
+        helper.render_async(
+          "users",
+          retry_delay: 3000,
         )
       end
     end
@@ -384,6 +427,7 @@ describe RenderAsync::ViewHelper do
             error_message: nil,
             error_event_name: nil,
             retry_count: 0,
+            retry_delay: nil,
             interval: 5000,
             content_for_name: :render_async
           }
@@ -415,6 +459,7 @@ describe RenderAsync::ViewHelper do
             error_message: nil,
             error_event_name: nil,
             retry_count: 0,
+            retry_delay: nil,
             interval: nil,
             content_for_name: :render_async_other_name
           }


### PR DESCRIPTION
Closes https://github.com/renderedtext/render_async/issues/80

This PR allows you to make `render_async` retry a request after some time. For example, if you want to retry a request 2 times, and want to make the delay of 3 seconds before making another try, you can do something like this:

```erb
<%= render_async users_path,
                 error_event_name: 'error-event-retry',
                 retry_count: 2,
                 retry_delay: 3000 do %>
  ...Loading <%= users_path %>
<% end %>

<p id="error-event-retry-paragraph"></p>

<script>
  document.addEventListener('error-event-retry', function(event) {
    var p = document.getElementById('error-event-retry-paragraph');

    p.innerHTML = "Request failed after " + event.retryCount + " tries!"
  });
</script>
```

By defining `retry_count: 2`, there will be total of 2 retries. When you set `retry_delay` to 3000, the `render_async` will retry the request each time after 3000ms (or 3 seconds).

Also, by catching an error event, you can get the total number of retries it took to load a specific resource.