### PR TITLE
Fix readme configuration-options anchor

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,7 +198,7 @@ Rendered code in the view:
 </div>
 ```
 
-> :bulb:  You can enable `nonce` to be set everywhere by using [configuration option](#configuration-option) render_async provides.
+> :bulb:  You can enable `nonce` to be set everywhere by using [configuration option](#configuration-options) render_async provides.
 
 ### Passing in an HTML element name
 


### PR DESCRIPTION
Thanks for the great gem! Have been using this for a few years now.

Encountered this super minor thing here; an incorrect anchor to the configuration-options section.