### PR TITLE
Avoid TypeError if container has already disappear

### DIFF
--- a/app/views/render_async/_request_jquery.js.erb
+++ b/app/views/render_async/_request_jquery.js.erb
@@ -50,6 +50,8 @@ if (window.jQuery) {
         headers: headers
       }).done(function(response) {
         var container = $("#<%= container_id %>");
+        if (!container.length) return;
+
         <% if !interval && replace_container %>
           container.replaceWith(response);
         <% else %>
@@ -73,6 +75,8 @@ if (window.jQuery) {
         if (skipErrorMessage) return;
 
         var container = $("#<%= container_id %>");
+        if (!container.length) return;
+
         container.replaceWith("<%= error_message.try(:html_safe) %>");
 
         var errorEvent = createEvent(

--- a/app/views/render_async/_request_vanilla.js.erb
+++ b/app/views/render_async/_request_vanilla.js.erb
@@ -60,6 +60,8 @@
       if (request.readyState === 4) {
         if (request.status >= SUCCESS && request.status < ERROR) {
           var container = document.getElementById('<%= container_id %>');
+          if (!container) return;
+
           <% if !interval && replace_container %>
           container.outerHTML = request.response;
           <% else %>
@@ -82,6 +84,8 @@
           if (skipErrorMessage) return;
 
           var container = document.getElementById('<%= container_id %>');
+          if (!container) return;
+
           container.outerHTML = '<%= error_message.try(:html_safe) %>';
 
           var errorEvent = createEvent(


### PR DESCRIPTION
### Summary

(In case of using Turbolinks or Turbo) When user fires render_async, and user move another page before async complete, then it raise TypeError:

```
TypeError: null is not an object (evaluating 'container.outerHTML = request.response')
```

This commit is for avoid this error, Thanks.