### PR TITLE
[ci skip] Wrap html_options for turbolinks

### DIFF
--- a/README.md
+++ b/README.md
@@ -622,7 +622,7 @@ Another option:
 If you want, you can tell Turbolinks to reload your `render_async` call as follows:
 
 ```erb
-<%= render_async events_path, 'data-turbolinks-track': 'reload' %>
+<%= render_async events_path, html_options: { 'data-turbolinks-track': 'reload' } %>
 ```
 
 This will reload the whole page with Turbolinks.
@@ -652,7 +652,7 @@ Another option:
 If you want, you can tell Turbo to reload your `render_async` call as follows:
 
 ```erb
-<%= render_async events_path, 'data-turbo-track': 'reload' %>
+<%= render_async events_path, html_options: { 'data-turbo-track': 'reload' } %>
 ```
 
 This will reload the whole page with Turbo.


### PR DESCRIPTION
`javascript_tag` method seems to require options as `html_options`.

https://github.com/renderedtext/render_async/blob/0efa941e9b3d5345df338bd7518bbf2687e93cb9/app/views/render_async/_render_async.html.erb#L9