### PR TITLE
Add support for retry count header

### DIFF
--- a/README.md
+++ b/README.md
@@ -402,6 +402,20 @@ Here is an example on how to get `retryCount`:
 </script>
 ```
 
+If you need to pass retry count to the backend, you can set `retry_count_header`: and then
+
+```erb
+<%= render_async users_path,
+                 retry_count: 5,
+                 retry_count_header: 'Retry-Count-Current' %>
+```
+
+And then in controller read the value from request headers.
+
+```
+request.headers['Retry-Count-Current']&.to_i
+```
+
 ### Toggle event
 
 You can trigger `render_async` loading by clicking or doing another event to a

--- a/app/views/render_async/_render_async.html.erb
+++ b/app/views/render_async/_render_async.html.erb
@@ -18,6 +18,7 @@
                   error_message: error_message,
                   error_event_name: error_event_name,
                   retry_count: retry_count,
+                  retry_count_header: retry_count_header,
                   retry_delay: retry_delay,
                   interval: interval,
                   turbolinks: RenderAsync.configuration.turbolinks,

--- a/app/views/render_async/_request_jquery.js.erb
+++ b/app/views/render_async/_request_jquery.js.erb
@@ -39,9 +39,15 @@ if (window.jQuery) {
 
     function _makeRequest(currentRetryCount) {
       var headers = <%= headers.to_json.html_safe %>;
-      var csrfTokenElement = document.querySelector('meta[name="csrf-token"]')
+      var csrfTokenElement = document.querySelector('meta[name="csrf-token"]');
       if (csrfTokenElement)
-        headers['X-CSRF-Token'] = csrfTokenElement.content
+        headers['X-CSRF-Token'] = csrfTokenElement.content;
+
+      <% if retry_count_header %>
+      if (typeof(currentRetryCount) === 'number') {
+        headers['<%= retry_count_header.html_safe %>'] = currentRetryCount;
+      }
+      <% end %>
 
       $.ajax({
         url: '<%= path.html_safe %>',
@@ -100,6 +106,8 @@ if (window.jQuery) {
         _makeRequest(currentRetryCount)
       }, <%= retry_delay %>)
     }
+    <% else %>
+    _retryMakeRequest = _makeRequest
     <% end %>
 
     function retry(currentRetryCount) {

--- a/app/views/render_async/_request_vanilla.js.erb
+++ b/app/views/render_async/_request_vanilla.js.erb
@@ -46,9 +46,15 @@
     request.open('<%= method %>', '<%= path.html_safe %>', asyncRequest);
 
     var headers = <%= headers.to_json.html_safe %>;
-    var csrfTokenElement = document.querySelector('meta[name="csrf-token"]')
+    var csrfTokenElement = document.querySelector('meta[name="csrf-token"]');
     if (csrfTokenElement)
-      headers['X-CSRF-Token'] = csrfTokenElement.content
+      headers['X-CSRF-Token'] = csrfTokenElement.content;
+
+    <% if retry_count_header %>
+    if (typeof(currentRetryCount) === 'number') {
+      headers['<%= retry_count_header.html_safe %>'] = currentRetryCount;
+    }
+    <% end %>
 
     Object.keys(headers).map(function(key) {
       request.setRequestHeader(key, headers[key]);
@@ -108,11 +114,13 @@
   <% if retry_count > 0 %>
 
   <% if retry_delay %>
-  _retryMakeRequest = function(currentRetryCount) {
+  var _retryMakeRequest = function(currentRetryCount) {
     setTimeout(function() {
       _makeRequest(currentRetryCount)
     }, <%= retry_delay %>)
   }
+  <% else %>
+  var _retryMakeRequest = _makeRequest
   <% end %>
 
   function retry(currentRetryCount) {

--- a/lib/render_async/view_helper.rb
+++ b/lib/render_async/view_helper.rb
@@ -63,6 +63,7 @@ module RenderAsync
     def retry_options(options)
       {
         retry_count: options.delete(:retry_count) || 0,
+        retry_count_header: options.delete(:retry_count_header),
         retry_delay: options.delete(:retry_delay)
       }
     end

--- a/spec/render_async/view_helper_spec.rb
+++ b/spec/render_async/view_helper_spec.rb
@@ -57,6 +57,7 @@ describe RenderAsync::ViewHelper do
             error_message: nil,
             error_event_name: nil,
             retry_count: 0,
+            retry_count_header: nil,
             retry_delay: nil,
             interval: nil,
             content_for_name: :render_async
@@ -93,6 +94,7 @@ describe RenderAsync::ViewHelper do
             error_message: nil,
             error_event_name: nil,
             retry_count: 0,
+            retry_count_header: nil,
             retry_delay: nil,
             interval: nil,
             content_for_name: :render_async
@@ -123,6 +125,7 @@ describe RenderAsync::ViewHelper do
             error_message: nil,
             error_event_name: nil,
             retry_count: 0,
+            retry_count_header: nil,
             retry_delay: nil,
             interval: nil,
             content_for_name: :render_async
@@ -153,6 +156,7 @@ describe RenderAsync::ViewHelper do
             error_message: nil,
             error_event_name: nil,
             retry_count: 0,
+            retry_count_header: nil,
             retry_delay: nil,
             interval: nil,
             content_for_name: :render_async
@@ -183,6 +187,7 @@ describe RenderAsync::ViewHelper do
             error_message: nil,
             error_event_name: nil,
             retry_count: 0,
+            retry_count_header: nil,
             retry_delay: nil,
             interval: nil,
             content_for_name: :render_async
@@ -213,6 +218,7 @@ describe RenderAsync::ViewHelper do
             error_message: nil,
             error_event_name: nil,
             retry_count: 0,
+            retry_count_header: nil,
             retry_delay: nil,
             interval: nil,
             content_for_name: :render_async
@@ -243,6 +249,7 @@ describe RenderAsync::ViewHelper do
             error_message: nil,
             error_event_name: nil,
             retry_count: 0,
+            retry_count_header: nil,
             retry_delay: nil,
             interval: nil,
             content_for_name: :render_async
@@ -273,6 +280,7 @@ describe RenderAsync::ViewHelper do
             error_message: nil,
             error_event_name: nil,
             retry_count: 0,
+            retry_count_header: nil,
             retry_delay: nil,
             interval: nil,
             content_for_name: :render_async
@@ -309,6 +317,7 @@ describe RenderAsync::ViewHelper do
             error_message: nil,
             error_event_name: nil,
             retry_count: 0,
+            retry_count_header: nil,
             retry_delay: nil,
             interval: nil,
             content_for_name: :render_async
@@ -339,6 +348,7 @@ describe RenderAsync::ViewHelper do
             error_message: nil,
             error_event_name: nil,
             retry_count: 0,
+            retry_count_header: nil,
             retry_delay: nil,
             interval: nil,
             content_for_name: :render_async
@@ -374,6 +384,7 @@ describe RenderAsync::ViewHelper do
             error_message: nil,
             error_event_name: nil,
             retry_count: 5,
+            retry_count_header: nil,
             retry_delay: nil,
             interval: nil,
             content_for_name: :render_async
@@ -383,6 +394,40 @@ describe RenderAsync::ViewHelper do
         helper.render_async(
           "users",
           retry_count: 5
+        )
+      end
+    end
+
+    context "retry_count_header is given" do
+      it "renders render_async partial with proper parameters" do
+        expect(helper).to receive(:render).with(
+          "render_async/render_async",
+          {
+            html_element_name: "div",
+            container_id: /render_async_/,
+            container_class: nil,
+            path: "users",
+            html_options: { nonce: false },
+            event_name: nil,
+            toggle: nil,
+            placeholder: nil,
+            replace_container: true,
+            method: 'GET',
+            data: nil,
+            headers: {},
+            error_message: nil,
+            error_event_name: nil,
+            retry_count: 0,
+            retry_count_header: "Retry-Count-Current",
+            retry_delay: nil,
+            interval: nil,
+            content_for_name: :render_async
+          }
+        )
+
+        helper.render_async(
+          "users",
+          retry_count_header: "Retry-Count-Current",
         )
       end
     end
@@ -407,6 +452,7 @@ describe RenderAsync::ViewHelper do
             error_message: nil,
             error_event_name: nil,
             retry_count: 0,
+            retry_count_header: nil,
             retry_delay: 3000,
             interval: nil,
             content_for_name: :render_async
@@ -440,6 +486,7 @@ describe RenderAsync::ViewHelper do
             error_message: nil,
             error_event_name: nil,
             retry_count: 0,
+            retry_count_header: nil,
             retry_delay: nil,
             interval: 5000,
             content_for_name: :render_async
@@ -473,6 +520,7 @@ describe RenderAsync::ViewHelper do
             error_message: nil,
             error_event_name: nil,
             retry_count: 0,
+            retry_count_header: nil,
             retry_delay: nil,
             interval: nil,
             content_for_name: :render_async_other_name
@@ -506,6 +554,7 @@ describe RenderAsync::ViewHelper do
             error_message: nil,
             error_event_name: nil,
             retry_count: 0,
+            retry_count_header: nil,
             retry_delay: nil,
             interval: nil,
             content_for_name: :render_async


### PR DESCRIPTION
Currently there's no way to tell on backend if request is being retried
or not. This change adds support for optional `retry_count_header`
parameter which configures request to include retry count in specified
header. (This is for example useful when you for example know that
previous request timed out and you want to reduce workload to try to
make it on time)

This change also fixes `retry_count` which is currently broken if
`retry_delay` is not specified.